### PR TITLE
Spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ server cluster as a [high availability backend](https://www.vaultproject.io/docs
 
 This Module includes:
 
-* [install-vault](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/install-valut): This module can be used to install Vault. It can be used in a 
+* [install-vault](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/install-vault): This module can be used to install Vault. It can be used in a 
   [Packer](https://www.packer.io/) template to create a Vault 
   [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html).
 

--- a/examples/vault-examples-helper/vault-examples-helper.sh
+++ b/examples/vault-examples-helper/vault-examples-helper.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# A script that is meant to be used with the private Valut cluster examples to:
+# A script that is meant to be used with the private Vault cluster examples to:
 #
 # 1. Wait for the Vault server cluster to come up.
 # 2. Print out the IP addresses of the Vault servers.

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -30,7 +30,7 @@ variable "allowed_inbound_security_group_ids" {
 }
 
 variable "user_data" {
-  description = "A User Data script to execute while the server is booting. We remmend passing in a bash script that executes the run-vault script, which should have been installed in the AMI by the install-vault module."
+  description = "A User Data script to execute while the server is booting. We recommend passing in a bash script that executes the run-vault script, which should have been installed in the AMI by the install-vault module."
 }
 
 variable "cluster_size" {

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -104,7 +104,7 @@ func runVaultPrivateClusterTest(t *testing.T, testName string, packerBuildName s
 	testVaultUsesConsulForDns(t, cluster, logger)
 }
 
-// Test the Valut public cluster example by:
+// Test the Vault public cluster example by:
 //
 // 1. Copy the code in this repo to a temp folder so tests on the Terraform code can run in parallel without the
 //    state files overwriting each other.


### PR DESCRIPTION
I noticed the link to the `install-vault` script in the readme was broken - fixed and found/fixed a couple of other tiny mistakes.