### PR TITLE
Facilitate specifying non-default VPC (shamelessly ripped off from hashicorp/terraform-aws-consul)

### DIFF
--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -123,7 +123,8 @@ data "template_file" "user_data_consul" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "aws_vpc" "default" {
-  default = true
+  default = "${var.vpc_id == "" ? true : false}"
+  id = "${var.vpc_id}"
 }
 
 data "aws_subnet_ids" "default" {

--- a/examples/vault-cluster-private/variables.tf
+++ b/examples/vault-cluster-private/variables.tf
@@ -72,3 +72,8 @@ variable "force_destroy_s3_bucket" {
   description = "If you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves."
   default     = false
 }
+
+variable "vpc_id" {
+    description = "The ID of the VPC in which the nodes will be deployed.  Uses default VPC if not supplied."
+    default = ""
+}

--- a/main.tf
+++ b/main.tf
@@ -202,7 +202,8 @@ data "template_file" "user_data_consul" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "aws_vpc" "default" {
-  default = true
+  default = "${var.vpc_id == "" ? true : false}"
+  id = "${var.vpc_id}"
 }
 
 data "aws_subnet_ids" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,8 @@ variable "force_destroy_s3_bucket" {
   description = "If you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves."
   default     = false
 }
+
+variable "vpc_id" {
+    description = "The ID of the VPC in which the nodes will be deployed.  Uses default VPC if not supplied."
+    default = ""
+}


### PR DESCRIPTION
Please let me know if you have troubles. I tested this with my local infrastructure (I actually needed it to get past not having a default VPC, which is "AWS Best Practice", at least today. ;) ).