### PR TITLE
fixes for consul references in vault cluster example. also upgrades referenced modules from v0.02 to v0.1.0

### DIFF
--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -51,7 +51,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.1.0"
 
   iam_role_id = "${module.vault_cluster.iam_role_id}"
 }
@@ -77,7 +77,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.1.0"
 
   cluster_name  = "${var.consul_cluster_name}"
   cluster_size  = "${var.consul_cluster_size}"
@@ -123,7 +123,8 @@ data "template_file" "user_data_consul" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "aws_vpc" "default" {
-  default = true
+  default = "${var.vpc_id == "" ? true : false}"
+  id      = "${var.vpc_id}"
 }
 
 data "aws_subnet_ids" "default" {

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -19,7 +19,7 @@ terraform {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-consul.git/modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
   cluster_name  = "${var.vault_cluster_name}"

--- a/examples/vault-cluster-private/outputs.tf
+++ b/examples/vault-cluster-private/outputs.tf
@@ -57,3 +57,27 @@ output "ssh_key_name" {
 output "vault_cluster_size" {
   value = "${var.vault_cluster_size}"
 }
+
+output "launch_config_name_servers" {
+  value = "${module.consul_cluster.launch_config_name}"
+}
+
+output "iam_role_arn_servers" {
+  value = "${module.consul_cluster.iam_role_arn}"
+}
+
+output "iam_role_id_servers" {
+  value = "${module.consul_cluster.iam_role_id}"
+}
+
+output "security_group_id_servers" {
+  value = "${module.consul_cluster.security_group_id}"
+}
+
+output "consul_cluster_cluster_tag_key" {
+  value = "${module.consul_cluster.cluster_tag_key}"
+}
+
+output "consul_cluster_cluster_tag_value" {
+  value = "${module.consul_cluster.cluster_tag_value}"
+}

--- a/modules/vault-security-group-rules/README.md
+++ b/modules/vault-security-group-rules/README.md
@@ -11,7 +11,7 @@ servers that have both Vault and Consul on each node:
 
 ```hcl
 module "cluster" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.0.1"
+  source = "github.com/hashicorp/terraform-aws-consul.git/modules/consul-cluster?ref=v0.0.1"
   
   # This AMI has both Vault and Consul installed
   ami_id = "ami-1234abcd"
@@ -24,7 +24,7 @@ servers have the necessary ports open for using Vault, you can use this module a
 
 ```hcl
 module "security_group_rules" {
-  source = "git::git@github.com:hashicorp/terraform-aws-vault.git//modules/vault-security-group-rules?ref=v0.0.1"
+  source = github.com/hashicorp/terraform-aws-consul.git/modules/vault-security-group-rules?ref=v0.0.1"
 
   security_group_id = "${module.cluster.security_group_id}"
   


### PR DESCRIPTION
this was causing terraform init to fail for me since I don't use ssh keys. 

the new format is also referenced in your documentation here. 

https://www.terraform.io/docs/modules/sources.html

as this is an example, I'm going to assume that the added security of an ssh privkey pull isn't a must have.