### PR TITLE
use splat syntax in fully_qualified_domain_name output

### DIFF
--- a/modules/vault-elb/outputs.tf
+++ b/modules/vault-elb/outputs.tf
@@ -15,5 +15,5 @@ output "load_balancer_security_group_id" {
 }
 
 output "fully_qualified_domain_name" {
-  value = "${aws_route53_record.vault_elb.fqdn}"
+  value = "${aws_route53_record.vault_elb.*.fqdn}"
 }

--- a/modules/vault-elb/outputs.tf
+++ b/modules/vault-elb/outputs.tf
@@ -15,5 +15,5 @@ output "load_balancer_security_group_id" {
 }
 
 output "fully_qualified_domain_name" {
-  value = "${aws_route53_record.vault_elb.*.fqdn}"
+  value = "${element(concat(aws_route53_record.vault_elb.*.fqdn, list("")), 0)}"
 }


### PR DESCRIPTION
Terraform >0.11.1 warns about non-splat references to resources with `count` defined.

This will become fatal in 0.12 (https://github.com/hashicorp/terraform/pull/16735)

See https://github.com/hashicorp/terraform/blob/v0.11.1/CHANGELOG.md
  