### PR TITLE
Switch to HTTPS for github.com module sources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ data "aws_ami" "vault_consul" {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-vault//modules/vault-cluster?ref=v0.0.1"
   source = "modules/vault-cluster"
 
   cluster_name  = "${var.vault_cluster_name}"
@@ -97,7 +97,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.0.2"
 
   iam_role_id = "${module.vault_cluster.iam_role_id}"
 }
@@ -125,7 +125,7 @@ data "template_file" "user_data_vault_cluster" {
 module "vault_elb" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:hashicorp/terraform-aws-vault.git//modules/vault-elb?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-vault//modules/vault-elb?ref=v0.0.1"
   source = "modules/vault-elb"
 
   name = "${var.vault_cluster_name}"
@@ -156,7 +156,7 @@ data "aws_route53_zone" "selected" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.0.2"
 
   cluster_name  = "${var.consul_cluster_name}"
   cluster_size  = "${var.consul_cluster_size}"


### PR DESCRIPTION
Terraform recognizes GitHub URLs explicitly [1] and convert them into
HTTPS URLs, which GitHub recommends [2].

This fixes issues we see in unattended execution environments (like
Terraform Enterprise) where `terraform init` fails because `git clone`
is unable to prompt the user for the `github.com` SSH Host Key and fails
with a message like this:

```
- module.vault.consul_iam_policies_servers
  Getting source "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.0.2"
Error downloading modules: Error loading modules: error downloading 'ssh://git@github.com/hashicorp/terraform-aws-consul.git?ref=v0.0.2': /usr/bin/git exited with 128: Cloning into '.terraform/modules/9abaf908332a7237423af5cdbc04386d'...
Host key verification failed.
fatal: Could not read from remote repository.
```

[1] https://www.terraform.io/docs/modules/sources.html#github
[2] https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended