### PR TITLE
Fix permissions on vault folders, cert files

### DIFF
--- a/examples/vault-consul-ami/vault-consul.json
+++ b/examples/vault-consul-ami/vault-consul.json
@@ -77,8 +77,9 @@
       "sudo mv /tmp/ca.crt.pem /opt/vault/tls/",
       "sudo mv /tmp/vault.crt.pem /opt/vault/tls/",
       "sudo mv /tmp/vault.key.pem /opt/vault/tls/",
-      "sudo chown vault:vault /opt/vault/tls/*",
-      "sudo chmod 600 /opt/vault/tls/*",
+      "sudo chown -R vault:vault /opt/vault/tls/",
+      "sudo chmod -R 600 /opt/vault/tls",
+      "sudo chmod 700 /opt/vault/tls",
       "sudo /tmp/terraform-aws-vault/modules/update-certificate-store/update-certificate-store --cert-file-path /opt/vault/tls/ca.crt.pem"
     ]
   },{

--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -77,17 +77,35 @@ function install_supervisord_debian {
   sudo systemctl enable supervisor
 }
 
+
+function two_way_symlink() {
+  local src="$1"
+  local dest="$2"
+
+  if [[ ! -f "$dest" ]] && [[ ! -f "$src" ]]; then
+    echo "Missing source '$src' AND destination '$dest' exiting..."
+    exit -5
+  fi
+
+  if [[ ! -f "$dest" ]]; then
+    ## Destination isn't there point it to source
+    sudo ln -s $src  $dest
+  elif [[ ! -f "$src" ]]; then
+    ## Source file was missing, point to destination.  Should ONLY do so if it doesn't already exist (e.g. hadn't already been dual linked)
+    sudo ln -s $dest $src
+  fi
+
+
+}
+
+
 # Install steps are based on: http://stackoverflow.com/a/31576473/483528
 function install_supervisord_amazon_linux {
   sudo pip install supervisor
 
   # On Amazon Linux, /usr/local/bin is not in PATH for the root user, so we add symlinks to /usr/bin, which is in PATH
-  if [[ ! -f "/usr/bin/supervisorctl" ]]; then
-    sudo ln -s /usr/local/bin/supervisorctl /usr/bin/supervisorctl
-  fi
-  if [[ ! -f "/usr/bin/supervisord" ]]; then
-    sudo ln -s /usr/local/bin/supervisord /usr/bin/supervisord
-  fi
+  two_way_symlink "/usr/bin/supervisorctl" "/usr/local/bin/supervisorctl"
+  two_way_symlink "/usr/bin/supervisord" "/usr/local/bin/supervisord"
 
   sudo cp "$SCRIPT_DIR/supervisor-initd-script.sh" "/etc/init.d/supervisor"
   sudo chmod a+x /etc/init.d/supervisor

--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -155,6 +155,8 @@ function create_vault_install_paths {
   sudo mkdir -p "$path/data"
   sudo mkdir -p "$path/log"
   sudo mkdir -p "$path/tls"
+  sudo chmod 755 "$path"
+  sudo chmod 755 "$path/bin"
 
   log_info "Changing ownership of $path to $username"
   sudo chown -R "$username:$username" "$path"


### PR DESCRIPTION
Vault folders when created with a 600 permissions (umask 0077) don't work when the default user tries to do a setcap command.  Further, TLS files can't have their permissions set via a /opt/vault/tls/* - wild cards don't work with chown when the folder isn't visibly to the requested user.  However, doing a recursive chown works as it doesn't need traversal permissions.  