### PR TITLE
Remove the 'availability_zones' parameter

### DIFF
--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -20,7 +20,6 @@ resource "aws_elb" "vault" {
   connection_draining_timeout = "${var.connection_draining_timeout}"
 
   security_groups    = ["${aws_security_group.vault.id}"]
-  availability_zones = ["${var.availability_zones}"]
   subnets            = ["${var.subnet_ids}"]
 
   # Run the ELB in TCP passthrough mode

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -27,12 +27,6 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "availability_zones" {
-  description = "The availability zones into which the ELB should be deployed. At least one of var.subnet_ids or var.availability_zones must be non-empty."
-  type        = "list"
-  default     = []
-}
-
 variable "create_dns_entry" {
   description = "If set to true, this module will create a Route 53 DNS A record for the ELB in the var.hosted_zone_id hosted zone with the domain name in var.domain_name."
   default     = false


### PR DESCRIPTION
This is alternate approach **A** for #19, simply removing the `availability_zones` parameter. The main effect of this is that ELBs on EC2-classic will no longer be supported.