### PR TITLE
Add lifecycle rule to ignore modifications to availability zones

### DIFF
--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -42,6 +42,9 @@ resource "aws_elb" "vault" {
   tags {
     Name = "${var.name}"
   }
+  lifecycle {
+    ignore_changes = ["availability_zones"]
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is alternate approach **B** for #19, adding a `lifecycle` rule to ignore changes to the `availability_zones` parameter. With this approach, ELBs on EC2-classic would still be supported, but changes to their availability zones won't be possible.