### PR TITLE
Add option creating individual instances, not ASG.

### DIFF
--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -1,5 +1,5 @@
 output "asg_name" {
-  value = "${aws_autoscaling_group.autoscaling_group.name}"
+  value = "${element(concat(aws_autoscaling_group.autoscaling_group.*.name, list("")), 0)}"
 }
 
 output "cluster_tag_key" {
@@ -11,11 +11,11 @@ output "cluster_tag_value" {
 }
 
 output "cluster_size" {
-  value = "${aws_autoscaling_group.autoscaling_group.desired_capacity}"
+  value = "${var.cluster_size}"
 }
 
 output "launch_config_name" {
-  value = "${aws_launch_configuration.launch_configuration.name}"
+  value = "${element(concat(aws_launch_configuration.launch_configuration.*.name, list("")), 0)}"
 }
 
 output "iam_role_arn" {
@@ -32,4 +32,18 @@ output "security_group_id" {
 
 output "s3_bucket_arn" {
   value = "${join(",", aws_s3_bucket.vault_storage.*.arn)}"
+}
+
+# Only available if not using an ASG.
+
+output "instance_ids" {
+  value = "${aws_instance.instance.*.id}"
+}
+
+output "instance_private_ips" {
+  value = "${aws_instance.instance.*.private_ip}"
+}
+
+output "instance_public_ips" {
+  value = "${aws_instance.instance.*.public_ip}"
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -42,6 +42,11 @@ variable "cluster_size" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "use_asg" {
+  description = "Use an EC2 Auto Scaling Group for the Vault cluster. If set to false, individual instances are created."
+  default = true
+}
+
 variable "subnet_ids" {
   description = "The subnet IDs into which the EC2 Instances should be deployed. You should typically pass in one subnet ID per node in the cluster_size variable. We strongly recommend that you run Vault in private subnets. At least one of var.subnet_ids or var.availability_zones must be non-empty."
   type        = "list"
@@ -72,7 +77,7 @@ variable "allowed_ssh_security_group_ids" {
 }
 
 variable "cluster_tag_key" {
-  description = "Add a tag with this key and the value var.cluster_name to each Instance in the ASG."
+  description = "Add a tag with this key and the value var.cluster_name to each instance."
   default     = "Name"
 }
 
@@ -89,6 +94,12 @@ variable "cluster_extra_tags" {
   #   } 
   # ]
   default = []
+}
+
+variable "instance_extra_tags" {
+  description = "A map of additional tags to add to each instance when creating individual instances rather than an ASG."
+  type = "map"
+  default = {}
 }
 
 variable "termination_policies" {
@@ -133,7 +144,7 @@ variable "target_group_arns" {
 }
 
 variable "load_balancers" {
-  description = "A list of Elastic Load Balancer (ELB) names to associate with this ASG. If you're using an Application Load Balancer (ALB), use the target_group_arns variable instead."
+  description = "A list of Elastic Load Balancer (ELB) names to associate with this ASG or each created instance. If you're using an Application Load Balancer (ALB), use the target_group_arns variable instead."
   type        = "list"
   default     = []
 }

--- a/modules/vault-instances-dns/main.tf
+++ b/modules/vault-instances-dns/main.tf
@@ -1,0 +1,20 @@
+resource "aws_route53_record" "instance_record" {
+  count = "${length(var.domain_names)}"
+
+  name = "${var.domain_names[count.index]}"
+  type = "A"
+  zone_id = "${var.hosted_zone_id}"
+  records = ["${var.instance_ips[count.index]}"]
+  ttl = "${var.ttl}"
+}
+
+resource "aws_route53_record" "srv_record" {
+  count = "${var.srv_domain_name == "" ? 0 : 1}"
+
+  name = "_${var.protocol}._tcp.${var.srv_domain_name}"
+  type = "SRV"
+  zone_id = "${var.hosted_zone_id}"
+  # Give equal priority (100) and weight (1) to each instance.
+  records = ["${formatlist("100 1 %s %s", var.api_port, var.domain_names)}"]
+  ttl = "${var.ttl}"
+}

--- a/modules/vault-instances-dns/variables.tf
+++ b/modules/vault-instances-dns/variables.tf
@@ -1,0 +1,32 @@
+variable "hosted_zone_id" {
+  description = "The Route 53 hosted zone ID in which to create a DNS A records and SRV record."
+}
+
+variable "instance_ips" {
+  description = "The instance IPs for which to create A records."
+  type = "list"
+}
+
+variable "domain_names" {
+  description = "The domain name to use for an A record to each instance IP."
+  type = "list"
+}
+
+variable "srv_domain_name" {
+  description = "The domain name to use for a SRV record resolving to all instance names."
+  default = ""
+}
+
+variable "api_port" {
+  description = "The port the Vault instances are listening on for API requests."
+  default     = 8200
+}
+
+variable "ttl" {
+  default = 60
+}
+
+variable "protocol" {
+  description = "The Vault API protocol (http or https, for use in SRV 'service' name)"
+  default = "https"
+}


### PR DESCRIPTION
Also add a module for setting up DNS records for a cluster of individual
instances, optionally includinge a SRV record resolving to all hosts.

In many ways creating individual EC2 instances is more desirable than an
Auto Scaling Group for a Vault cluster:

- Since instances typically require manual action to unseal, automatic
  creation of new instances doesn't buy you much.
- Individual instances are created with known IPs, making it easier to
  route requests to specific instances (e.g. for unsealing).
- Known IPs can be used to create DNS records referring to individual
  instances by name. This is as nice human affordance, but also greatly
  simplifies TLS communication with individual instances (which can hold
  a wildcard TLS cert valid for all instance DNS names).
- DNS discovery of instance addresses for unsealing avoids a
  chicken-and-egg problem with using the AWS CLI to look up instance
  addresses when you are using Vault to issue all your AWS CLI creds.