### PR TITLE
Use variable cluster_name as a name prefix for the autoscaling group

### DIFF
--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -48,7 +48,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.1.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.2.0"
 
   iam_role_id = "${module.vault_cluster.iam_role_id}"
 }
@@ -73,7 +73,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.1.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.2.0"
 
   cluster_name  = "${var.consul_cluster_name}"
   cluster_size  = "${var.consul_cluster_size}"

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -52,7 +52,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.1.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.2.0"
 
   iam_role_id = "${module.vault_cluster.iam_role_id}"
 }
@@ -78,7 +78,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.1.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.2.0"
 
   cluster_name  = "${var.consul_cluster_name}"
   cluster_size  = "${var.consul_cluster_size}"

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.2.0"
 
   iam_role_id = "${module.vault_cluster.iam_role_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ data "aws_route53_zone" "selected" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.2.0"
 
   cluster_name  = "${var.consul_cluster_name}"
   cluster_size  = "${var.consul_cluster_size}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -11,6 +11,8 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_autoscaling_group" "autoscaling_group" {
+  name_prefix = "${var.cluster_name}"
+
   launch_configuration = "${aws_launch_configuration.launch_configuration.name}"
 
   availability_zones  = ["${var.availability_zones}"]


### PR DESCRIPTION
Shamelessly copying https://github.com/hashicorp/terraform-aws-consul/pull/48 to implement it here. I'm even using the same branch name and PR title :) (thanks https://github.com/miguelaferreira!)

I do want to point out that in the PR above, the prefix of the [ASG group](https://github.com/hashicorp/terraform-aws-consul/blob/master/modules/consul-cluster/main.tf#L14) is set to `"${var.cluster_name}"` while the name prefix of the [launch configuration](https://github.com/hashicorp/terraform-aws-consul/blob/master/modules/consul-cluster/main.tf#L53) is `"${var.cluster_name}-"` (notice the trailing `-`), which may make people's OCD flare up. So, to at least make that consistent, I'm setting the prefix of the Vault ASG to `"${var.cluster_name}"` as well (i.e. without the trailing `-`).

By the way, I also updated the version of the consul-cluster module used in the root example, to use version 0.2.0, which is where the PR above was introduced. That's not required for this fix, so I can revert it if you believe that's more convenient.

As far as testing, I don't think the Terratest code validates the names, so I tested by running the root example and visually inspecting the names in my AWS console. Please let me know if there's any automated tests that would need to be changed/added.

Lastly, I don't think there's any documentation to be updated. In fact, in can be argued that this makes the module behavior consistent with the behavior implied by the description of the [`cluster_name`](https://github.com/hashicorp/terraform-aws-vault/blob/master/modules/vault-cluster/variables.tf#L7) variable. That said, the same warning as with the [0.2.0 version](https://github.com/hashicorp/terraform-aws-consul/releases/tag/v0.2.0) of the consul-cluster module should be given in the release notes (should this PR be accepted and merged), that simply applying `terraform apply` could bring the cluster down.