### PR TITLE
Permit consul traffic in vault sg

### DIFF
--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -70,12 +70,12 @@ data "template_file" "user_data_vault_cluster" {
 
 # ---------------------------------------------------------------------------------------------------------------------
 # PERMIT CONSUL SPECIFIC TRAFFIC IN VAULT CLUSTER
-# To allow our Vault servers consul agents to communication with consul agents and servers, we open up the consul
-# specific protocols and ports for consul traffic
+# To allow our Vault servers consul agents to communicate with other consul agents and participate in the LAN gossip,
+# we open up the consul specific protocols and ports for consul traffic
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-security-group-rules?ref=v0.3.1"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.3.1"
 
   security_group_id           = "${module.vault_cluster.security_group_id}"
 

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -69,6 +69,19 @@ data "template_file" "user_data_vault_cluster" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# PERMIT CONSUL SPECIFIC TRAFFIC IN VAULT CLUSTER
+# To allow our Vault servers consul agents to communication with consul agents and servers, we open up the consul
+# specific protocols and ports for consul traffic
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "security_group_rules" {
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-security-group-rules?ref=v0.3.1"
+
+  security_group_id           = "${module.vault_cluster.security_group_id}"
+  allowed_inbound_cidr_blocks = "${var.allowed_inbound_cidr_blocks}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # DEPLOY THE CONSUL SERVER CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -78,7 +78,11 @@ module "security_group_rules" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-security-group-rules?ref=v0.3.1"
 
   security_group_id           = "${module.vault_cluster.security_group_id}"
-  allowed_inbound_cidr_blocks = "${var.allowed_inbound_cidr_blocks}"
+
+  # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
+  # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
+  
+  allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -48,7 +48,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.2.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.3.3"
 
   iam_role_id = "${module.vault_cluster.iam_role_id}"
 }
@@ -75,7 +75,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.3.1"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.3.3"
 
   security_group_id           = "${module.vault_cluster.security_group_id}"
 
@@ -90,7 +90,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.2.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.3.3"
 
   cluster_name  = "${var.consul_cluster_name}"
   cluster_size  = "${var.consul_cluster_size}"

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -52,7 +52,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.2.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.3.3"
 
   iam_role_id = "${module.vault_cluster.iam_role_id}"
 }
@@ -74,11 +74,28 @@ data "template_file" "user_data_vault_cluster" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# PERMIT CONSUL SPECIFIC TRAFFIC IN VAULT CLUSTER
+# To allow our Vault servers consul agents to communicate with other consul agents and participate in the LAN gossip,
+# we open up the consul specific protocols and ports for consul traffic
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "security_group_rules" {
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.3.3"
+
+  security_group_id           = "${module.vault_cluster.security_group_id}"
+
+  # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
+  # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
+  
+  allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # DEPLOY THE CONSUL SERVER CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.2.0"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.3.3"
 
   cluster_name  = "${var.consul_cluster_name}"
   cluster_size  = "${var.consul_cluster_size}"


### PR DESCRIPTION
Adding the `security_group_rules` from `terraform-aws-consul` to permit the consul agents on the vault cluster to talk freely.

I used the `v0.3.1` tag (which is different from the one used in the example) as that's what I used in my local provisioning.