### PR TITLE
Updated the parameter name redirect_addr to its new name: api_addr

### DIFF
--- a/examples/vault-consul-ami/vault-consul.json
+++ b/examples/vault-consul-ami/vault-consul.json
@@ -2,7 +2,7 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "vault_version": "0.8.2",
+    "vault_version": "0.10.0",
     "consul_module_version": "v0.0.2",
     "consul_version": "0.9.3",
     "github_oauth_token": "{{env `GITHUB_OAUTH_TOKEN`}}",

--- a/modules/install-vault/README.md
+++ b/modules/install-vault/README.md
@@ -21,7 +21,7 @@ for all available tags) and run the `install-vault` script:
 
 ```
 git clone --branch <VERSION> https://github.com/hashicorp/terraform-aws-vault.git
-terraform-aws-vault/modules/install-vault/install-vault --version 0.5.4
+terraform-aws-vault/modules/install-vault/install-vault --version 0.10.0
 ```
 
 The `install-vault` script will install Vault, its dependencies, and the [run-vault script](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/run-vault).
@@ -49,7 +49,7 @@ The `install-vault` script accepts the following arguments:
 Example:
 
 ```
-install-vault --version 0.7.0
+install-vault --version 0.10.0
 ```
 
 

--- a/modules/run-vault/README.md
+++ b/modules/run-vault/README.md
@@ -101,11 +101,11 @@ available.
       connection is to a Consul agent running on the same server.
     * [path](https://www.vaultproject.io/docs/configuration/storage/consul.html#path): Set to `vault/`.
     * [service](https://www.vaultproject.io/docs/configuration/storage/consul.html#service): Set to `vault`.  
-    * [redirect_addr](https://www.vaultproject.io/docs/configuration/storage/consul.html#redirect_addr): 
+    * [api_addr](https://www.vaultproject.io/docs/configuration/index.html#api_addr): 
       Set to `https://<PRIVATE_IP>:<CLUSTER_PORT>` where `PRIVATE_IP` is the Instance's private IP fetched from
       [Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) and `CLUSTER_PORT` is
       the value passed to `--cluster-port`.  
-    * [cluster_addr](https://www.vaultproject.io/docs/configuration/storage/consul.html#cluster_addr): 
+    * [cluster_addr](https://www.vaultproject.io/docs/configuration/index.html#cluster_addr): 
       Set to `https://<PRIVATE_IP>:<CLUSTER_PORT>` where `PRIVATE_IP` is the Instance's private IP fetched from
       [Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) and `CLUSTER_PORT` is
       the value passed to `--cluster-port`.

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -151,7 +151,7 @@ $consul_storage_type "consul" {
 
   # HA settings
   cluster_addr  = "https://$instance_ip_address:$cluster_port"
-  redirect_addr = "https://$instance_ip_address:$cluster_port"
+  api_addr = "https://$instance_ip_address:$cluster_port"
 }
 EOF
 )

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -151,7 +151,7 @@ $consul_storage_type "consul" {
 
   # HA settings
   cluster_addr  = "https://$instance_ip_address:$cluster_port"
-  api_addr = "https://$instance_ip_address:$cluster_port"
+  api_addr      = "https://$instance_ip_address:$cluster_port"
 }
 EOF
 )


### PR DESCRIPTION
The parameter redirect_addr no longer works in the latest Vault release: 0.10.0.  All mention of it has also been scrubbed from the online documentation.  I've changed it to api_addr in the run-vault module and changed the documentation to link to the new command and to use installation of Vault 0.10.0 in its examples.  

Tested by deploying a cluster running Vault 0.10.0.