### PR TITLE
Ability to specify additional security groups

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -48,7 +48,7 @@ resource "aws_launch_configuration" "launch_configuration" {
 
   iam_instance_profile        = "${aws_iam_instance_profile.instance_profile.name}"
   key_name                    = "${var.ssh_key_name}"
-  security_groups             = ["${aws_security_group.lc_security_group.id}"]
+  security_groups             = ["${concat(list(aws_security_group.lc_security_group.id), var.additional_security_group_ids)}"]
   placement_tenancy           = "${var.tenancy}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
 

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -71,6 +71,12 @@ variable "allowed_ssh_security_group_ids" {
   default     = []
 }
 
+variable "additional_security_group_ids" {
+  description = "A list of additional security group IDs to add to Vault EC2 Instances"
+  type        = "list"
+  default     = []
+}
+
 variable "cluster_tag_key" {
   description = "Add a tag with this key and the value var.cluster_name to each Instance in the ASG."
   default     = "Name"


### PR DESCRIPTION
This PR adds the ability to specify additional security groups to attach to the launch configuration. An example usage is a Consul security group. It's much easier to attach a security group that defines the security rules for a Consul cluster than adding the rules individually.

A new, optional variable has been added: `additional_security_group_ids`
This variable accepts a list of security group IDs to attach to the launch configuration. By default, it is empty.

**Downtime needed:** No.
This change does not require downtime. The default behavior does not force a change.

**Backwards compatible:** Yes.
The default behavior works identically as it does without this PR.

The change was tested in our AWS account in three scenarios:
1. Existing cluster without specifying the `additional_security_group_ids` variable. No changes showed up in the plan.
2. Existing cluster with the `additional_security_group_ids` variable. A new launch configuration was created and the ASG was updated to use it. No instances were stopped or created.
3. New cluster with the `additional_security_group_ids` variable. Attached all security groups as expected.