### PR TITLE
Remove provider and aws_region from examples

### DIFF
--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -30,15 +30,17 @@ production usage, we strongly recommend deploying the Vault cluster into the pri
 To deploy a Vault Cluster:
 
 1. `git clone` this repo to your computer.
-1. Build a Vault and Consul AMI. See the [vault-consul-ami example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) documentation for 
+1. Optional: build a Vault and Consul AMI. See the [vault-consul-ami
+   example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) documentation for
    instructions. Make sure to note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
 1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default, including putting your AMI ID into the `ami_id` variable.
-1. Run `terraform get`.
-1. Run `terraform plan`.
-1. If the plan looks good, run `terraform apply`.
-1. Run the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) to 
+   don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of our
+   public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
+   recommended for production use.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. Run the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) to
    print out the IP addresses of the Vault servers and some example commands you can run to interact with the cluster:
    `../vault-examples-helper/vault-examples-helper.sh`.
    

--- a/examples/vault-cluster-private/README.md
+++ b/examples/vault-cluster-private/README.md
@@ -32,15 +32,17 @@ production usage, we strongly recommend deploying the Vault cluster into the pri
 To deploy a Vault Cluster:
 
 1. `git clone` this repo to your computer.
-1. Build a Vault and Consul AMI. See the [vault-consul-ami example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) documentation for 
+1. Optional: build a Vault and Consul AMI. See the [vault-consul-ami
+   example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) documentation for
    instructions. Make sure to note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
 1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default, including putting your AMI ID into the `ami_id` variable.
-1. Run `terraform get`.
-1. Run `terraform plan`.
-1. If the plan looks good, run `terraform apply`.
-1. Run the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) to 
+   don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of our
+   public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
+   recommended for production use.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. Run the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) to
    print out the IP addresses of the Vault servers and some example commands you can run to interact with the cluster:
    `../vault-examples-helper/vault-examples-helper.sh`.
 

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -4,10 +4,6 @@
 # running in a separate cluster, as its storage backend.
 # ---------------------------------------------------------------------------------------------------------------------
 
-provider "aws" {
-  region = "${var.aws_region}"
-}
-
 terraform {
   required_version = ">= 0.9.3"
 }
@@ -62,7 +58,7 @@ data "template_file" "user_data_vault_cluster" {
   template = "${file("${path.module}/user-data-vault.sh")}"
 
   vars {
-    aws_region               = "${var.aws_region}"
+    aws_region               = "${data.aws_region.current.name}"
     consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
     consul_cluster_tag_value = "${var.consul_cluster_name}"
   }
@@ -143,3 +139,5 @@ data "aws_vpc" "default" {
 data "aws_subnet_ids" "default" {
   vpc_id = "${data.aws_vpc.default.id}"
 }
+
+data "aws_region" "current" {}

--- a/examples/vault-cluster-private/outputs.tf
+++ b/examples/vault-cluster-private/outputs.tf
@@ -39,7 +39,7 @@ output "security_group_id_consul_cluster" {
 }
 
 output "aws_region" {
-  value = "${var.aws_region}"
+  value = "${data.aws_region.current.name}"
 }
 
 output "vault_servers_cluster_tag_key" {

--- a/examples/vault-cluster-private/variables.tf
+++ b/examples/vault-cluster-private/variables.tf
@@ -5,6 +5,7 @@
 
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
 
 # ---------------------------------------------------------------------------------------------------------------------
 # REQUIRED PARAMETERS
@@ -23,11 +24,6 @@ variable "ssh_key_name" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
-
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
-}
 
 variable "vault_cluster_name" {
   description = "What to name the Vault server cluster and all of its associated resources"

--- a/examples/vault-s3-backend/README.md
+++ b/examples/vault-s3-backend/README.md
@@ -32,15 +32,17 @@ production usage, we strongly recommend deploying the Vault cluster into the pri
 To deploy a Vault Cluster:
 
 1. `git clone` this repo to your computer.
-1. Build a Vault and Consul AMI. See the [vault-consul-ami example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) documentation for 
+1. Optional: build a Vault and Consul AMI. See the [vault-consul-ami
+   example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) documentation for
    instructions. Make sure to note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
 1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default, including putting your AMI ID into the `ami_id` variable.
-1. Run `terraform get`.
-1. Run `terraform plan`.
-1. If the plan looks good, run `terraform apply`.
-1. Run the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) to 
+   don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of our
+   public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
+   recommended for production use.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. Run the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) to
    print out the IP addresses of the Vault servers and some example commands you can run to interact with the cluster:
    `../vault-examples-helper/vault-examples-helper.sh`.
 

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -4,10 +4,6 @@
 # running in a separate cluster, as its storage backend.
 # ---------------------------------------------------------------------------------------------------------------------
 
-provider "aws" {
-  region = "${var.aws_region}"
-}
-
 terraform {
   required_version = ">= 0.9.3"
 }
@@ -66,7 +62,7 @@ data "template_file" "user_data_vault_cluster" {
   template = "${file("${path.module}/user-data-vault.sh")}"
 
   vars {
-    aws_region               = "${var.aws_region}"
+    aws_region               = "${data.aws_region.current.name}"
     s3_bucket_name           = "${var.s3_bucket_name}"
     consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
     consul_cluster_tag_value = "${var.consul_cluster_name}"
@@ -148,3 +144,5 @@ data "aws_vpc" "default" {
 data "aws_subnet_ids" "default" {
   vpc_id = "${data.aws_vpc.default.id}"
 }
+
+data "aws_region" "current" {}

--- a/examples/vault-s3-backend/outputs.tf
+++ b/examples/vault-s3-backend/outputs.tf
@@ -39,7 +39,7 @@ output "security_group_id_consul_cluster" {
 }
 
 output "aws_region" {
-  value = "${var.aws_region}"
+  value = "${data.aws_region.current.name}"
 }
 
 output "vault_servers_cluster_tag_key" {

--- a/examples/vault-s3-backend/variables.tf
+++ b/examples/vault-s3-backend/variables.tf
@@ -5,6 +5,7 @@
 
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
 
 # ---------------------------------------------------------------------------------------------------------------------
 # REQUIRED PARAMETERS
@@ -23,11 +24,6 @@ variable "ssh_key_name" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
-
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
-}
 
 variable "vault_cluster_name" {
   description = "What to name the Vault server cluster and all of its associated resources"

--- a/main.tf
+++ b/main.tf
@@ -5,10 +5,6 @@
 # backend.
 # ---------------------------------------------------------------------------------------------------------------------
 
-provider "aws" {
-  region = "${var.aws_region}"
-}
-
 # Terraform 0.9.5 suffered from https://github.com/hashicorp/terraform/issues/14399, which causes this template the
 # conditionals in this template to fail.
 terraform {
@@ -105,7 +101,7 @@ data "template_file" "user_data_vault_cluster" {
   template = "${file("${path.module}/examples/root-example/user-data-vault.sh")}"
 
   vars {
-    aws_region               = "${var.aws_region}"
+    aws_region               = "${data.aws_region.current.name}"
     consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
     consul_cluster_tag_value = "${var.consul_cluster_name}"
   }
@@ -225,3 +221,5 @@ data "aws_subnet_ids" "default" {
   vpc_id = "${data.aws_vpc.default.id}"
   tags   = "${var.subnet_tags}"
 }
+
+data "aws_region" "current" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,7 +47,7 @@ output "security_group_id_consul_cluster" {
 }
 
 output "aws_region" {
-  value = "${var.aws_region}"
+  value = "${data.aws_region.current.name}"
 }
 
 output "vault_servers_cluster_tag_key" {

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -34,8 +34,8 @@
 [[projects]]
   name = "github.com/gruntwork-io/terratest"
   packages = ["modules/aws","modules/collections","modules/files","modules/logger","modules/packer","modules/random","modules/retry","modules/shell","modules/ssh","modules/terraform","modules/test-structure"]
-  revision = "b9eaa580d17795b28ac89173b066d951c6feb3c4"
-  version = "v0.9.1"
+  revision = "baaee143a328ab0fe3a78a0ebc80bb0f707ef8fc"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.9.1"
+  version = "0.9.2"
 
 [[constraint]]
   name = "github.com/hashicorp/vault"

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -22,7 +22,8 @@ import (
 
 const REPO_ROOT = "../"
 
-const VAR_AWS_REGION = "aws_region"
+const ENV_VAR_AWS_REGION = "aws_region"
+
 const VAR_AMI_ID = "ami_id"
 const VAR_VAULT_CLUSTER_NAME = "vault_cluster_name"
 const VAR_CONSUL_CLUSTER_NAME = "consul_cluster_name"
@@ -120,11 +121,13 @@ func runVaultPrivateClusterTest(t *testing.T, packerBuildName string, sshUserNam
 			TerraformDir: examplesDir,
 			Vars: map[string]interface{}{
 				VAR_AMI_ID:                 amiId,
-				VAR_AWS_REGION:             awsRegion,
 				VAR_VAULT_CLUSTER_NAME:     fmt.Sprintf("vault-test-%s", uniqueId),
 				VAR_CONSUL_CLUSTER_NAME:    fmt.Sprintf("consul-test-%s", uniqueId),
 				VAR_CONSUL_CLUSTER_TAG_KEY: fmt.Sprintf("consul-test-%s", uniqueId),
 				VAR_SSH_KEY_NAME:           keyPair.Name,
+			},
+			EnvVars: map[string]string{
+				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
 
@@ -193,7 +196,6 @@ func runVaultPublicClusterTest(t *testing.T, packerBuildName string, sshUserName
 			TerraformDir: examplesDir,
 			Vars: map[string]interface{}{
 				VAR_AMI_ID:                                       amiId,
-				VAR_AWS_REGION:                                   awsRegion,
 				VAR_VAULT_CLUSTER_NAME:                           fmt.Sprintf("vault-test-%s", uniqueId),
 				VAR_CONSUL_CLUSTER_NAME:                          fmt.Sprintf("consul-test-%s", uniqueId),
 				VAR_CONSUL_CLUSTER_TAG_KEY:                       fmt.Sprintf("consul-test-%s", uniqueId),
@@ -201,6 +203,9 @@ func runVaultPublicClusterTest(t *testing.T, packerBuildName string, sshUserName
 				VAULT_CLUSTER_PUBLIC_VAR_CREATE_DNS_ENTRY:        boolToTerraformVar(false),
 				VAULT_CLUSTER_PUBLIC_VAR_HOSTED_ZONE_DOMAIN_NAME: "",
 				VAULT_CLUSTER_PUBLIC_VAR_VAULT_DOMAIN_NAME:       "",
+			},
+			EnvVars: map[string]string{
+				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
 
@@ -269,7 +274,6 @@ func runVaultWithS3BackendClusterTest(t *testing.T, packerBuildName string, sshU
 			TerraformDir: examplesDir,
 			Vars: map[string]interface{}{
 				VAR_AMI_ID:                  amiId,
-				VAR_AWS_REGION:              awsRegion,
 				VAR_VAULT_CLUSTER_NAME:      fmt.Sprintf("vault-test-%s", uniqueId),
 				VAR_CONSUL_CLUSTER_NAME:     fmt.Sprintf("consul-test-%s", uniqueId),
 				VAR_CONSUL_CLUSTER_TAG_KEY:  fmt.Sprintf("consul-test-%s", uniqueId),
@@ -277,6 +281,9 @@ func runVaultWithS3BackendClusterTest(t *testing.T, packerBuildName string, sshU
 				VAR_ENABLE_S3_BACKEND:       boolToTerraformVar(true),
 				VAR_S3_BUCKET_NAME:          s3BucketName(uniqueId),
 				VAR_FORCE_DESTROY_S3_BUCKET: boolToTerraformVar(true),
+			},
+			EnvVars: map[string]string{
+				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
 

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -101,13 +101,13 @@ func runVaultPrivateClusterTest(t *testing.T, packerBuildName string, sshUserNam
 
 	test_structure.RunTestStage(t, "setup_ami", func() {
 		awsRegion := aws.GetRandomRegion(t, nil, nil)
+		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
+
 		tlsCert := generateSelfSignedTlsCert(t)
+		saveTlsCert(t, examplesDir, tlsCert)
 
 		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, tlsCert, awsRegion)
-
 		test_structure.SaveAmiId(t, examplesDir, amiId)
-		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
-		saveTlsCert(t, examplesDir, tlsCert)
 	})
 
 	test_structure.RunTestStage(t, "deploy", func() {
@@ -116,6 +116,7 @@ func runVaultPrivateClusterTest(t *testing.T, packerBuildName string, sshUserNam
 		awsRegion := test_structure.LoadString(t, examplesDir, SAVED_AWS_REGION)
 
 		keyPair := aws.CreateAndImportEC2KeyPair(t, awsRegion, uniqueId)
+		test_structure.SaveEc2KeyPair(t, examplesDir, keyPair)
 
 		terraformOptions := &terraform.Options{
 			TerraformDir: examplesDir,
@@ -130,11 +131,9 @@ func runVaultPrivateClusterTest(t *testing.T, packerBuildName string, sshUserNam
 				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
+		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
 
 		terraform.InitAndApply(t, terraformOptions)
-
-		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
-		test_structure.SaveEc2KeyPair(t, examplesDir, keyPair)
 	})
 
 	test_structure.RunTestStage(t, "validate", func() {
@@ -176,13 +175,13 @@ func runVaultPublicClusterTest(t *testing.T, packerBuildName string, sshUserName
 
 	test_structure.RunTestStage(t, "setup_ami", func() {
 		awsRegion := aws.GetRandomRegion(t, nil, nil)
+		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
+
 		tlsCert := generateSelfSignedTlsCert(t)
+		saveTlsCert(t, examplesDir, tlsCert)
 
 		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, tlsCert, awsRegion)
-
 		test_structure.SaveAmiId(t, examplesDir, amiId)
-		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
-		saveTlsCert(t, examplesDir, tlsCert)
 	})
 
 	test_structure.RunTestStage(t, "deploy", func() {
@@ -191,6 +190,7 @@ func runVaultPublicClusterTest(t *testing.T, packerBuildName string, sshUserName
 		awsRegion := test_structure.LoadString(t, examplesDir, SAVED_AWS_REGION)
 
 		keyPair := aws.CreateAndImportEC2KeyPair(t, awsRegion, uniqueId)
+		test_structure.SaveEc2KeyPair(t, examplesDir, keyPair)
 
 		terraformOptions := &terraform.Options{
 			TerraformDir: examplesDir,
@@ -208,11 +208,9 @@ func runVaultPublicClusterTest(t *testing.T, packerBuildName string, sshUserName
 				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
+		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
 
 		terraform.InitAndApply(t, terraformOptions)
-
-		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
-		test_structure.SaveEc2KeyPair(t, examplesDir, keyPair)
 	})
 
 	test_structure.RunTestStage(t, "validate", func() {
@@ -254,13 +252,13 @@ func runVaultWithS3BackendClusterTest(t *testing.T, packerBuildName string, sshU
 
 	test_structure.RunTestStage(t, "setup_ami", func() {
 		awsRegion := aws.GetRandomRegion(t, nil, nil)
+		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
+
 		tlsCert := generateSelfSignedTlsCert(t)
+		saveTlsCert(t, examplesDir, tlsCert)
 
 		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, tlsCert, awsRegion)
-
 		test_structure.SaveAmiId(t, examplesDir, amiId)
-		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
-		saveTlsCert(t, examplesDir, tlsCert)
 	})
 
 	test_structure.RunTestStage(t, "deploy", func() {
@@ -269,6 +267,7 @@ func runVaultWithS3BackendClusterTest(t *testing.T, packerBuildName string, sshU
 		awsRegion := test_structure.LoadString(t, examplesDir, SAVED_AWS_REGION)
 
 		keyPair := aws.CreateAndImportEC2KeyPair(t, awsRegion, uniqueId)
+		test_structure.SaveEc2KeyPair(t, examplesDir, keyPair)
 
 		terraformOptions := &terraform.Options{
 			TerraformDir: examplesDir,
@@ -286,11 +285,9 @@ func runVaultWithS3BackendClusterTest(t *testing.T, packerBuildName string, sshU
 				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
+		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
 
 		terraform.InitAndApply(t, terraformOptions)
-
-		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
-		test_structure.SaveEc2KeyPair(t, examplesDir, keyPair)
 	})
 
 	test_structure.RunTestStage(t, "validate", func() {

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -22,7 +22,7 @@ import (
 
 const REPO_ROOT = "../"
 
-const ENV_VAR_AWS_REGION = "aws_region"
+const ENV_VAR_AWS_REGION = "AWS_DEFAULT_REGION"
 
 const VAR_AMI_ID = "ami_id"
 const VAR_VAULT_CLUSTER_NAME = "vault_cluster_name"

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@
 
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
 
 # ---------------------------------------------------------------------------------------------------------------------
 # REQUIRED PARAMETERS
@@ -39,22 +40,19 @@ variable "ssh_key_name" {
 
 variable "subnet_tags" {
   description = "Tags used to find subnets for vault and consul servers"
+  type        = "map"
   default     = {}
 }
 
 variable "vpc_tags" {
   description = "Tags used to find a vpc for building resources in"
+  type        = "map"
   default     = {}
 }
 
 variable "use_default_vpc" {
   description = "Whether to use the default VPC - NOT recommended for production! - should more likely change this to false and use the vpc_tags to find your vpc"
   default     = true
-}
-
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
 }
 
 variable "vault_cluster_name" {


### PR DESCRIPTION
I’m removing the `provider` block and `aws_region` variable from the examples in this repo so that they work properly with the instructions you get from the auto-generated docs on the [Terraform Registry page](https://registry.terraform.io/modules/hashicorp/vault/aws/0.6.1) for this module.