### PR TITLE
Value of 'count' cannot be computed fix

### DIFF
--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -35,10 +35,11 @@ module "vault_cluster" {
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 
-  allowed_ssh_cidr_blocks            = ["0.0.0.0/0"]
-  allowed_inbound_cidr_blocks        = ["0.0.0.0/0"]
-  allowed_inbound_security_group_ids = []
-  ssh_key_name                       = "${var.ssh_key_name}"
+  allowed_ssh_cidr_blocks              = ["0.0.0.0/0"]
+  allowed_inbound_cidr_blocks          = ["0.0.0.0/0"]
+  allowed_inbound_security_group_ids   = []
+  allowed_inbound_security_group_count = 0
+  ssh_key_name                         = "${var.ssh_key_name}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -39,10 +39,11 @@ module "vault_cluster" {
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 
-  allowed_ssh_cidr_blocks            = ["0.0.0.0/0"]
-  allowed_inbound_cidr_blocks        = ["0.0.0.0/0"]
-  allowed_inbound_security_group_ids = []
-  ssh_key_name                       = "${var.ssh_key_name}"
+  allowed_ssh_cidr_blocks              = ["0.0.0.0/0"]
+  allowed_inbound_cidr_blocks          = ["0.0.0.0/0"]
+  allowed_inbound_security_group_ids   = []
+  allowed_inbound_security_group_count = 0
+  ssh_key_name                         = "${var.ssh_key_name}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -81,10 +81,11 @@ module "vault_cluster" {
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 
-  allowed_ssh_cidr_blocks            = ["0.0.0.0/0"]
-  allowed_inbound_cidr_blocks        = ["0.0.0.0/0"]
-  allowed_inbound_security_group_ids = []
-  ssh_key_name                       = "${var.ssh_key_name}"
+  allowed_ssh_cidr_blocks              = ["0.0.0.0/0"]
+  allowed_inbound_cidr_blocks          = ["0.0.0.0/0"]
+  allowed_inbound_security_group_ids   = []
+  allowed_inbound_security_group_count = 0
+  ssh_key_name                         = "${var.ssh_key_name}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -133,7 +133,7 @@ module "security_group_rules" {
   security_group_id                    = "${aws_security_group.lc_security_group.id}"
   allowed_inbound_cidr_blocks          = ["${var.allowed_inbound_cidr_blocks}"]
   allowed_inbound_security_group_ids   = ["${var.allowed_inbound_security_group_ids}"]
-  allowed_inbound_security_group_count = "${length(["${var.allowed_inbound_security_group_ids}"])}"
+  allowed_inbound_security_group_count = 1
 
   api_port     = "${var.api_port}"
   cluster_port = "${var.cluster_port}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -130,9 +130,10 @@ resource "aws_security_group_rule" "allow_all_outbound" {
 module "security_group_rules" {
   source = "../vault-security-group-rules"
 
-  security_group_id                  = "${aws_security_group.lc_security_group.id}"
-  allowed_inbound_cidr_blocks        = ["${var.allowed_inbound_cidr_blocks}"]
-  allowed_inbound_security_group_ids = ["${var.allowed_inbound_security_group_ids}"]
+  security_group_id                        = "${aws_security_group.lc_security_group.id}"
+  allowed_inbound_cidr_blocks              = ["${var.allowed_inbound_cidr_blocks}"]
+  allowed_inbound_security_group_ids       = ["${var.allowed_inbound_security_group_ids}"]
+  allowed_inbound_security_group_ids_count = "${length(var.allowed_inbound_security_group_ids)}"
 
   api_port     = "${var.api_port}"
   cluster_port = "${var.cluster_port}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -133,7 +133,7 @@ module "security_group_rules" {
   security_group_id                    = "${aws_security_group.lc_security_group.id}"
   allowed_inbound_cidr_blocks          = ["${var.allowed_inbound_cidr_blocks}"]
   allowed_inbound_security_group_ids   = ["${var.allowed_inbound_security_group_ids}"]
-  allowed_inbound_security_group_count = 5
+  allowed_inbound_security_group_count = "${var.allowed_inbound_security_group_count}"
 
   api_port     = "${var.api_port}"
   cluster_port = "${var.cluster_port}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -130,10 +130,10 @@ resource "aws_security_group_rule" "allow_all_outbound" {
 module "security_group_rules" {
   source = "../vault-security-group-rules"
 
-  security_group_id                        = "${aws_security_group.lc_security_group.id}"
-  allowed_inbound_cidr_blocks              = ["${var.allowed_inbound_cidr_blocks}"]
-  allowed_inbound_security_group_ids       = ["${var.allowed_inbound_security_group_ids}"]
-  allowed_inbound_security_group_ids_count = "${length(var.allowed_inbound_security_group_ids)}"
+  security_group_id                    = "${aws_security_group.lc_security_group.id}"
+  allowed_inbound_cidr_blocks          = ["${var.allowed_inbound_cidr_blocks}"]
+  allowed_inbound_security_group_ids   = ["${var.allowed_inbound_security_group_ids}"]
+  allowed_inbound_security_group_count = "${length(var.allowed_inbound_security_group_ids)}"
 
   api_port     = "${var.api_port}"
   cluster_port = "${var.cluster_port}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -133,7 +133,7 @@ module "security_group_rules" {
   security_group_id                    = "${aws_security_group.lc_security_group.id}"
   allowed_inbound_cidr_blocks          = ["${var.allowed_inbound_cidr_blocks}"]
   allowed_inbound_security_group_ids   = ["${var.allowed_inbound_security_group_ids}"]
-  allowed_inbound_security_group_count = 1
+  allowed_inbound_security_group_count = 5
 
   api_port     = "${var.api_port}"
   cluster_port = "${var.cluster_port}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -133,7 +133,7 @@ module "security_group_rules" {
   security_group_id                    = "${aws_security_group.lc_security_group.id}"
   allowed_inbound_cidr_blocks          = ["${var.allowed_inbound_cidr_blocks}"]
   allowed_inbound_security_group_ids   = ["${var.allowed_inbound_security_group_ids}"]
-  allowed_inbound_security_group_count = "${length(var.allowed_inbound_security_group_ids)}"
+  allowed_inbound_security_group_count = "${length(["${var.allowed_inbound_security_group_ids}"])}"
 
   api_port     = "${var.api_port}"
   cluster_port = "${var.cluster_port}"

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -29,6 +29,10 @@ variable "allowed_inbound_security_group_ids" {
   type        = "list"
 }
 
+variable "allowed_inbound_security_group_count" {
+  description = "A count of allowed_inbound_security_group_ids used internally due to terraform limitation"
+}
+
 variable "user_data" {
   description = "A User Data script to execute while the server is booting. We recommend passing in a bash script that executes the run-vault script, which should have been installed in the AMI by the install-vault module."
 }
@@ -80,13 +84,13 @@ variable "cluster_extra_tags" {
   description = "A list of additional tags to add to each Instance in the ASG. Each element in the list must be a map with the keys key, value, and propagate_at_launch"
   type        = "list"
 
-  #example: 
+  #example:
   # default = [
   #   {
   #     key = "Environment"
   #     value = "Dev"
   #     propagate_at_launch = true
-  #   } 
+  #   }
   # ]
   default = []
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -30,7 +30,7 @@ variable "allowed_inbound_security_group_ids" {
 }
 
 variable "allowed_inbound_security_group_count" {
-  description = "A count of allowed_inbound_security_group_ids used internally due to terraform limitation"
+  description = "The number of entries in var.allowed_inbound_security_group_ids. Ideally, this value could be computed dynamically, but we pass this variable to a Terraform resource's 'count' property and Terraform requires that 'count' be computed with literals or data sources only."
 }
 
 variable "user_data" {

--- a/modules/vault-security-group-rules/main.tf
+++ b/modules/vault-security-group-rules/main.tf
@@ -2,6 +2,11 @@
 # CREATE THE SECURITY GROUP RULES THAT CONTROL WHAT TRAFFIC CAN GO IN AND OUT OF A VAULT CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "group_count" {
+}
+
+group_count = "${length(var.allowed_inbound_security_group_ids)}"
+
 resource "aws_security_group_rule" "allow_api_inbound_from_cidr_blocks" {
   count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"
   type        = "ingress"
@@ -14,7 +19,7 @@ resource "aws_security_group_rule" "allow_api_inbound_from_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "allow_api_inbound_from_security_group_ids" {
-  count                    = "${length(var.allowed_inbound_security_group_ids)}"
+  count                    = "${var.group_count}"
   type                     = "ingress"
   from_port                = "${var.api_port}"
   to_port                  = "${var.api_port}"

--- a/modules/vault-security-group-rules/main.tf
+++ b/modules/vault-security-group-rules/main.tf
@@ -2,10 +2,7 @@
 # CREATE THE SECURITY GROUP RULES THAT CONTROL WHAT TRAFFIC CAN GO IN AND OUT OF A VAULT CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "group_count" {
-}
-
-group_count = "${length(var.allowed_inbound_security_group_ids)}"
+allowed_inbound_security_group_count = "${length(var.allowed_inbound_security_group_ids)}"
 
 resource "aws_security_group_rule" "allow_api_inbound_from_cidr_blocks" {
   count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"

--- a/modules/vault-security-group-rules/main.tf
+++ b/modules/vault-security-group-rules/main.tf
@@ -2,8 +2,6 @@
 # CREATE THE SECURITY GROUP RULES THAT CONTROL WHAT TRAFFIC CAN GO IN AND OUT OF A VAULT CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 
-allowed_inbound_security_group_count = "${length(var.allowed_inbound_security_group_ids)}"
-
 resource "aws_security_group_rule" "allow_api_inbound_from_cidr_blocks" {
   count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"
   type        = "ingress"
@@ -16,7 +14,7 @@ resource "aws_security_group_rule" "allow_api_inbound_from_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "allow_api_inbound_from_security_group_ids" {
-  count                    = "${var.group_count}"
+  count                    = "${var.allowed_inbound_security_group_count}"
   type                     = "ingress"
   from_port                = "${var.api_port}"
   to_port                  = "${var.api_port}"

--- a/modules/vault-security-group-rules/variables.tf
+++ b/modules/vault-security-group-rules/variables.tf
@@ -22,6 +22,10 @@ variable "allowed_inbound_security_group_ids" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "allowed_inbound_security_group_count" {
+  description = "A count of allowed_inbound_security_group_ids used internally"
+}
+
 variable "api_port" {
   description = "The port to use for Vault API calls"
   default     = 8200

--- a/modules/vault-security-group-rules/variables.tf
+++ b/modules/vault-security-group-rules/variables.tf
@@ -23,8 +23,7 @@ variable "allowed_inbound_security_group_ids" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 variable "allowed_inbound_security_group_count" {
-  description = "A count of allowed_inbound_security_group_ids used internally"
-  default = "${length(var.allowed_inbound_security_group_ids)}"
+  description = "A count of allowed_inbound_security_group_ids used internally due to terraform limitation"
 }
 
 variable "api_port" {

--- a/modules/vault-security-group-rules/variables.tf
+++ b/modules/vault-security-group-rules/variables.tf
@@ -23,7 +23,7 @@ variable "allowed_inbound_security_group_ids" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 variable "allowed_inbound_security_group_count" {
-  description = "A count of allowed_inbound_security_group_ids used internally due to terraform limitation"
+  description = "The number of entries in var.allowed_inbound_security_group_ids. Ideally, this value could be computed dynamically, but we pass this variable to a Terraform resource's 'count' property and Terraform requires that 'count' be computed with literals or data sources only."
 }
 
 variable "api_port" {

--- a/modules/vault-security-group-rules/variables.tf
+++ b/modules/vault-security-group-rules/variables.tf
@@ -24,6 +24,7 @@ variable "allowed_inbound_security_group_ids" {
 
 variable "allowed_inbound_security_group_count" {
   description = "A count of allowed_inbound_security_group_ids used internally"
+  default = "${length(var.allowed_inbound_security_group_ids)}"
 }
 
 variable "api_port" {


### PR DESCRIPTION
Hello, 

Ran into this issue with the recent version of terraform and vault_cluster:

```
module.pg_vault_cluster.module.security_group_rules.aws_security_group_rule.allow_api_inbound_from_security_group_ids: aws_security_group_rule.allow_api_inbound_from_security_group_ids: value of 'count' cannot be computed
```

Here is the fix I made for this issue. Let me know if you have any feedback.