### PR TITLE
Allow custom API address

### DIFF
--- a/modules/run-vault/README.md
+++ b/modules/run-vault/README.md
@@ -1,6 +1,6 @@
 # Vault Run Script
 
-This folder contains a script for configuring and running Vault on an [AWS](https://aws.amazon.com/) server. This 
+This folder contains a script for configuring and running Vault on an [AWS](https://aws.amazon.com/) server. This
 script has been tested on the following operating systems:
 
 * Ubuntu 16.04
@@ -13,8 +13,8 @@ There is a good chance it will work on other flavors of Debian, CentOS, and RHEL
 
 ## Quick start
 
-This script assumes you installed it, plus all of its dependencies (including Vault itself), using the [install-vault 
-module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/install-vault). The default install path is `/opt/vault/bin`, so to start Vault in server mode, you 
+This script assumes you installed it, plus all of its dependencies (including Vault itself), using the [install-vault
+module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/install-vault). The default install path is `/opt/vault/bin`, so to start Vault in server mode, you
 run:
 
 ```
@@ -26,19 +26,19 @@ This will:
 1. Generate a Vault configuration file called `default.hcl` in the Vault config dir (default: `/opt/vault/config`).
    See [Vault configuration](#vault-configuration) for details on what this configuration file will contain and how
    to override it with your own configuration.
-   
+
 1. Generate a [Supervisor](http://supervisord.org/) configuration file called `run-vault.conf` in the Supervisor
-   config dir (default: `/etc/supervisor/conf.d`) with a command that will run Vault:  
+   config dir (default: `/etc/supervisor/conf.d`) with a command that will run Vault:
    `vault server -config=/opt/vault/config`.
 
 1. Tell Supervisor to load the new configuration file, thereby starting Vault.
 
-We recommend using the `run-vault` command as part of [User 
+We recommend using the `run-vault` command as part of [User
 Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts), so that it executes
-when the EC2 Instance is first booting. After running `run-vault` on that initial boot, the `supervisord` configuration 
+when the EC2 Instance is first booting. After running `run-vault` on that initial boot, the `supervisord` configuration
 will automatically restart Vault if it crashes or the EC2 instance reboots.
 
-See the [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and 
+See the [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and
 [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) examples for fully-working sample code.
 
 
@@ -48,19 +48,20 @@ See the [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/
 
 The `run-vault` script accepts the following arguments:
 
-* `--tls-cert-file` (required): Specifies the path to the certificate for TLS. To configure the listener to use a CA 
-  certificate, concatenate the primary certificate and the CA certificate together. The primary certificate should 
+* `--tls-cert-file` (required): Specifies the path to the certificate for TLS. To configure the listener to use a CA
+  certificate, concatenate the primary certificate and the CA certificate together. The primary certificate should
   appear first in the combined file. See [How do you handle encryption?](#how-do-you_handle-encryption) for more info.
-* `--tls-key-file` (required): Specifies the path to the private key for the certificate. See [How do you handle 
+* `--tls-key-file` (required): Specifies the path to the private key for the certificate. See [How do you handle
   encryption?](#how-do-you_handle-encryption) for more info.
-* `--port` (optional): The port Vault should listen on. Default is `8200`.   
-* `--log-level` (optional): The log verbosity to use with Vault. Default is `info`.   
-* `--cluster-port` (optional): The port Vault should listen on for server-to-server communication. Default is 
-  `--port + 1`.   
-* `config-dir` (optional): The path to the Vault config folder. Default is to take the absolute path of `../config`, 
+* `--port` (optional): The port Vault should listen on. Default is `8200`.
+* `--log-level` (optional): The log verbosity to use with Vault. Default is `info`.
+* `--cluster-port` (optional): The port Vault should listen on for server-to-server communication. Default is
+  `--port + 1`.
+* `--api-addr`: The full address to use for [Client Redirection](https://www.vaultproject.io/docs/concepts/ha.html#client-redirection) when running Vault in HA mode. Defaults to "https://[instance_ip]:8200". Optional.
+* `config-dir` (optional): The path to the Vault config folder. Default is to take the absolute path of `../config`,
   relative to the `run-vault` script itself.
 * `user` (optional): The user to run Vault as. Default is to use the owner of `config-dir`.
-* `skip-vault-config` (optional): If this flag is set, don't generate a Vault configuration file. This is useful if you 
+* `skip-vault-config` (optional): If this flag is set, don't generate a Vault configuration file. This is useful if you
   have a custom configuration file and don't want to use any of of the default settings from `run-vault`.
 * `--enable-s3-backend` (optional): If this flag is set, an S3 backend will be enabled in addition to the HA Consul backend.
 * `--s3-bucket` (optional): Specifies the S3 bucket to use to store Vault data. Only used if `--s3-backend-enabled` is set.
@@ -82,45 +83,45 @@ Or if you want to enable an S3 backend:
 
 ## Vault configuration
 
-`run-vault` generates a configuration file for Vault called `default.hcl` that tries to figure out reasonable 
-defaults for a Vault cluster in AWS. Check out the [Vault Configuration Files 
+`run-vault` generates a configuration file for Vault called `default.hcl` that tries to figure out reasonable
+defaults for a Vault cluster in AWS. Check out the [Vault Configuration Files
 documentation](https://www.vaultproject.io/docs/configuration/index.html) for what configuration settings are
 available.
-  
-  
+
+
 ### Default configuration
 
 `run-vault` sets the following configuration values by default:
-* [api_addr](https://www.vaultproject.io/docs/configuration/index.html#api_addr): 
+* [api_addr](https://www.vaultproject.io/docs/configuration/index.html#api_addr):
       Set to `https://<PRIVATE_IP>:<PORT>` where `PRIVATE_IP` is the Instance's private IP fetched from
       [Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) and `PORT` is
-      the value passed to `--port`.  
-* [cluster_addr](https://www.vaultproject.io/docs/configuration/index.html#cluster_addr): 
+      the value passed to `--port`.
+* [cluster_addr](https://www.vaultproject.io/docs/configuration/index.html#cluster_addr):
       Set to `https://<PRIVATE_IP>:<CLUSTER_PORT>` where `PRIVATE_IP` is the Instance's private IP fetched from
       [Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) and `CLUSTER_PORT` is
       the value passed to `--cluster-port`.
 
 * [storage](https://www.vaultproject.io/docs/configuration/index.html#storage): Configure Consul as the storage backend
   with the following settings:
- 
-    * [address](https://www.vaultproject.io/docs/configuration/storage/consul.html#address): Set the address to 
+
+    * [address](https://www.vaultproject.io/docs/configuration/storage/consul.html#address): Set the address to
       `127.0.0.1:8500`. This is based on the assumption that the Consul agent is running on the same server.
     * [scheme](https://www.vaultproject.io/docs/configuration/storage/consul.html#scheme): Set to `http` since our
       connection is to a Consul agent running on the same server.
     * [path](https://www.vaultproject.io/docs/configuration/storage/consul.html#path): Set to `vault/`.
-    * [service](https://www.vaultproject.io/docs/configuration/storage/consul.html#service): Set to `vault`.  
+    * [service](https://www.vaultproject.io/docs/configuration/storage/consul.html#service): Set to `vault`.
 
-      
-* [listener](https://www.vaultproject.io/docs/configuration/index.html#listener): Configure a [TCP 
+
+* [listener](https://www.vaultproject.io/docs/configuration/index.html#listener): Configure a [TCP
   listener](https://www.vaultproject.io/docs/configuration/listener/tcp.html) with the following settings:
 
-    * [address](https://www.vaultproject.io/docs/configuration/listener/tcp.html#address): Bind to `0.0.0.0:<PORT>` 
+    * [address](https://www.vaultproject.io/docs/configuration/listener/tcp.html#address): Bind to `0.0.0.0:<PORT>`
       where `PORT` is the value passed to `--port`.
-    * [cluster_address](https://www.vaultproject.io/docs/configuration/listener/tcp.html#cluster_address): Bind to 
+    * [cluster_address](https://www.vaultproject.io/docs/configuration/listener/tcp.html#cluster_address): Bind to
       `0.0.0.0:<CLUSTER_PORT>` where `CLUSTER` is the value passed to `--cluster-port`.
-    * [tls_cert_file](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_cert_file): Set to the 
+    * [tls_cert_file](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_cert_file): Set to the
       `--tls-cert-file` parameter.
-    * [tls_key_file](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_key_file): Set to the 
+    * [tls_key_file](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_key_file): Set to the
       `--tls-key-file` parameter.
 
 `run-vault` can optionally set the following configuration values:
@@ -135,10 +136,10 @@ available.
 
 ### Overriding the configuration
 
-To override the default configuration, simply put your own configuration file in the Vault config folder (default: 
-`/opt/vault/config`), but with a name that comes later in the alphabet than `default.hcl` (e.g. 
-`my-custom-config.hcl`). Vault will load all the `.hcl` configuration files in the config dir and merge them together 
-in alphabetical order, so that settings in files that come later in the alphabet will override the earlier ones. 
+To override the default configuration, simply put your own configuration file in the Vault config folder (default:
+`/opt/vault/config`), but with a name that comes later in the alphabet than `default.hcl` (e.g.
+`my-custom-config.hcl`). Vault will load all the `.hcl` configuration files in the config dir and merge them together
+in alphabetical order, so that settings in files that come later in the alphabet will override the earlier ones.
 
 For example, to set a custom `cluster_name` setting, you could create a file called `name.hcl` with the
 contents:
@@ -167,7 +168,7 @@ Vault uses TLS to encrypt all data in transit. To configure encryption, you must
 
 ### Provide TLS certificates
 
-When you execute the `run-vault` script, you need to provide the paths to the public and private keys of a TLS 
+When you execute the `run-vault` script, you need to provide the paths to the public and private keys of a TLS
 certificate:
 
 ```
@@ -183,10 +184,10 @@ Since this Vault Module uses Consul as a storage backend (and optionally S3), yo
 Note that Vault encrypts any data *before* sending it to a storage backend, so this isn't strictly necessary, but may be a good
 extra layer of security.
 
-By default, the Vault server nodes communicate with a local Consul agent running on the same server over (unencrypted) 
-HTTP. However, you can configure those agents to talk to the Consul servers using TLS. Check out the [official Consul 
-encryption docs](https://www.consul.io/docs/agent/encryption.html) and the Consul AWS Module [How do you handle 
+By default, the Vault server nodes communicate with a local Consul agent running on the same server over (unencrypted)
+HTTP. However, you can configure those agents to talk to the Consul servers using TLS. Check out the [official Consul
+encryption docs](https://www.consul.io/docs/agent/encryption.html) and the Consul AWS Module [How do you handle
 encryption docs](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-consul#how-do-you-handle-encryption)
 for more info.
- 
+
 

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -109,7 +109,7 @@ function generate_vault_config {
   local readonly tls_key_file="$2"
   local readonly port="$3"
   local readonly cluster_port="$4"
-  local api_addr="$5"
+  local readonly api_addr="$5"
   local readonly config_dir="$6"
   local readonly user="$7"
   local readonly enable_s3_backend="$8"
@@ -119,11 +119,6 @@ function generate_vault_config {
 
   local instance_ip_address
   instance_ip_address=$(get_instance_ip_address)
-
-
-  if [[ -z "$api_addr" ]]; then
-    api_addr="https://${instance_ip_address}:${port}"
-  fi
 
   log_info "Creating default Vault config file in $config_path"
   local readonly listener_config=$(cat <<EOF
@@ -333,6 +328,10 @@ function run {
 
   if [[ -z "$cluster_port" ]]; then
     cluster_port=$(( $port + 1 ))
+  fi
+
+  if [[ -z "$api_addr" ]]; then
+    api_addr="https://$(get_instance_ip_address):${port}"
   fi
 
   if [[ "$skip_vault_config" == "true" ]]; then

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -26,6 +26,7 @@ function print_usage {
   echo -e "  --tls-key-file\tSpecifies the path to the private key for the certificate. Required."
   echo -e "  --port\t\tThe port for Vault to listen on. Optional. Default is $DEFAULT_PORT."
   echo -e "  --cluster-port\tThe port for Vault to listen on for server-to-server requests. Optional. Default is --port + 1."
+  echo -e "  --api-addr\t\tThe full address to use for Client Redirection when running Vault in HA mode. Defaults to \"https://[instance_ip]:$DEFAULT_PORT\". Optional."
   echo -e "  --config-dir\t\tThe path to the Vault config folder. Optional. Default is the absolute path of '../config', relative to this script."
   echo -e "  --bin-dir\t\tThe path to the folder with Vault binary. Optional. Default is the absolute path of the parent folder of this script."
   echo -e "  --log-dir\t\tThe path to the Vault log folder. Optional. Default is the absolute path of '../log', relative to this script."
@@ -108,15 +109,21 @@ function generate_vault_config {
   local readonly tls_key_file="$2"
   local readonly port="$3"
   local readonly cluster_port="$4"
-  local readonly config_dir="$5"
-  local readonly user="$6"
-  local readonly enable_s3_backend="$7"
-  local readonly s3_bucket="$8"
-  local readonly s3_bucket_region="$9"
+  local api_addr="$5"
+  local readonly config_dir="$6"
+  local readonly user="$7"
+  local readonly enable_s3_backend="$8"
+  local readonly s3_bucket="$9"
+  local readonly s3_bucket_region="${10}"
   local readonly config_path="$config_dir/$VAULT_CONFIG_FILE"
 
   local instance_ip_address
   instance_ip_address=$(get_instance_ip_address)
+
+
+  if [[ -z "$api_addr" ]]; then
+    api_addr="https://${instance_ip_address}:${port}"
+  fi
 
   log_info "Creating default Vault config file in $config_path"
   local readonly listener_config=$(cat <<EOF
@@ -152,7 +159,7 @@ $consul_storage_type "consul" {
 
 # HA settings
 cluster_addr  = "https://$instance_ip_address:$cluster_port"
-api_addr      = "https://$instance_ip_address:$port"
+api_addr      = "$api_addr"
 
 EOF
 )
@@ -203,6 +210,7 @@ function run {
   local tls_key_file=""
   local port="$DEFAULT_PORT"
   local cluster_port=""
+  local api_addr=""
   local config_dir=""
   local bin_dir=""
   local log_dir=""
@@ -239,6 +247,11 @@ function run {
       --config-dir)
         assert_not_empty "$key" "$2"
         config_dir="$2"
+        shift
+        ;;
+       --api-addr)
+        assert_not_empty "$key" "$2"
+        api_addr="$2"
         shift
         ;;
       --bin-dir)
@@ -325,7 +338,7 @@ function run {
   if [[ "$skip_vault_config" == "true" ]]; then
     log_info "The --skip-vault-config flag is set, so will not generate a default Vault config file."
   else
-    generate_vault_config "$tls_cert_file" "$tls_key_file" "$port" "$cluster_port" "$config_dir" "$user" "$enable_s3_backend" "$s3_bucket" "$s3_bucket_region"
+    generate_vault_config "$tls_cert_file" "$tls_key_file" "$port" "$cluster_port" "$api_addr" "$config_dir" "$user" "$enable_s3_backend" "$s3_bucket" "$s3_bucket_region"
   fi
 
   generate_supervisor_config "$SUPERVISOR_CONFIG_PATH" "$config_dir" "$bin_dir" "$log_dir" "$log_level" "$user"


### PR DESCRIPTION
Due to a change in [Vault](https://github.com/hashicorp/vault/pull/4272), Vault will refuse to start up if `cluster_addr == api_addr`.

This PR incorporates #61 and furthers add a flag for the user to specify their own `api_addr` if they intend to use HA client redirection and they are running Vault behind a load balancer.

The documentation on [Vault's HA](https://www.vaultproject.io/docs/concepts/ha.html) page indicates that `cluster_addr` and `api_addr` should be top level keys.

I have tested this by bootstrapping my own Vault cluster successfully. 