### PR TITLE
Mark vault user as system user

### DIFF
--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -159,7 +159,7 @@ function create_vault_user {
     echo "User $username already exists. Will not create again."
   else
     log_info "Creating user named $username"
-    sudo useradd "$username"
+    sudo useradd --system "$username"
   fi
 }
 


### PR DESCRIPTION
To follow unix conventions, mark the vault user as system user. It gives the user UID from another range. Some scripts (ie. our user management agent) distinguishes between "service" (system) users and "people" user.