### PR TITLE
Added support for Vault UI

### DIFF
--- a/modules/run-vault/README.md
+++ b/modules/run-vault/README.md
@@ -92,6 +92,9 @@ available.
 ### Default configuration
 
 `run-vault` sets the following configuration values by default:
+* [ui](https://www.vaultproject.io/docs/configuration/index.html#ui):
+      Set to "ui = true" only when the installed vault version is >=0.10.0.
+
 * [api_addr](https://www.vaultproject.io/docs/configuration/index.html#api_addr):
       Set to `https://<PRIVATE_IP>:<PORT>` where `PRIVATE_IP` is the Instance's private IP fetched from
       [Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) and `PORT` is

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -13,6 +13,7 @@ readonly EC2_INSTANCE_METADATA_URL="http://169.254.169.254/latest/meta-data"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
+readonly VAULT_VERSION=$(vault -v|awk '{print $2}'|tr -d v)
 
 function print_usage {
   echo
@@ -121,6 +122,12 @@ function generate_vault_config {
   instance_ip_address=$(get_instance_ip_address)
 
   log_info "Creating default Vault config file in $config_path"
+  local readonly ui_config=$(cat <<EOF
+ui = true
+
+EOF
+)
+
   local readonly listener_config=$(cat <<EOF
 listener "tcp" {
   address         = "0.0.0.0:$port"
@@ -159,6 +166,11 @@ api_addr      = "$api_addr"
 EOF
 )
 
+if [ $(echo "$VAULT_VERSION 0.10.0" | tr " " "\n" |sort --version-sort| head -n 1) = 0.10.0 ]; then
+    echo -e "$ui_config" >> "$config_path"
+  else
+    log_info "Vault 0.10.0 or greater is required for UI support."
+fi
   echo -e "$listener_config" >> "$config_path"
   echo -e "$s3_config" >> "$config_path"
   echo -e "$consul_storage" >> "$config_path"

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -104,11 +104,20 @@ function assert_is_installed {
   fi
 }
 
+function get_vault_version {
+  #Runs vault -v to get the vault version, then strips out everything but the version number.
+  #The current output format of vault -v is:
+  #Vault v0.10.4 ('e21712a687889de1125e0a12a980420b1a4f72d3')
+  /usr/local/bin/vault -v|awk '{print $2}'|tr -d v
+}
+
 function vault_version_at_least {
   local readonly config_path=$1
   local readonly ui_config=$2
-  local readonly VAULT_VERSION=$(/usr/local/bin/vault -v|awk '{print $2}'|tr -d v)
+  VAULT_VERSION=$(get_vault_version)
 
+  #This if statement will echo the current vault version and the minimum version required for ui support.
+  #It then strips out the comments, sorts the two values, and chooses the top (least) one.
   if [[ $(echo "$VAULT_VERSION 0.10.0" | tr " " "\n" |sort --version-sort| head -n 1) = 0.10.0 ]]
     then
       echo -e "$ui_config" >> "$config_path"

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -13,7 +13,6 @@ readonly EC2_INSTANCE_METADATA_URL="http://169.254.169.254/latest/meta-data"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
-readonly VAULT_VERSION=$(vault -v|awk '{print $2}'|tr -d v)
 
 function print_usage {
   echo
@@ -105,6 +104,19 @@ function assert_is_installed {
   fi
 }
 
+function vault_version_at_least {
+  local readonly config_path=$1
+  local readonly ui_config=$2
+  local readonly VAULT_VERSION=$(/usr/local/bin/vault -v|awk '{print $2}'|tr -d v)
+
+  if [[ $(echo "$VAULT_VERSION 0.10.0" | tr " " "\n" |sort --version-sort| head -n 1) = 0.10.0 ]]
+    then
+      echo -e "$ui_config" >> "$config_path"
+    else
+      log_info "Vault 0.10.0 or greater is required for UI support."
+  fi
+}
+
 function generate_vault_config {
   local readonly tls_cert_file="$1"
   local readonly tls_key_file="$2"
@@ -166,11 +178,7 @@ api_addr      = "$api_addr"
 EOF
 )
 
-if [ $(echo "$VAULT_VERSION 0.10.0" | tr " " "\n" |sort --version-sort| head -n 1) = 0.10.0 ]; then
-    echo -e "$ui_config" >> "$config_path"
-  else
-    log_info "Vault 0.10.0 or greater is required for UI support."
-fi
+  vault_version_at_least "$config_path" "$ui_config"
   echo -e "$listener_config" >> "$config_path"
   echo -e "$s3_config" >> "$config_path"
   echo -e "$consul_storage" >> "$config_path"


### PR DESCRIPTION
Addresses Issue #57 
The module/run-vault/run-vault script now:
1 - Gathers the installed vault version number
2 - Compares that version to the minimum version required for UI support using a similar comparison mechanism as found in [this stack overflow response](https://stackoverflow.com/a/47897019/5627332).
3 - Adds "ui = true" if the installed version is >=0.10.0

This was tested using v.0.9.6 and v.0.10.4 and everything worked as expected.