### PR TITLE
Add lb_tags to vault-elb module to provide additional tags

### DIFF
--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -19,8 +19,8 @@ resource "aws_elb" "vault" {
   connection_draining         = "${var.connection_draining}"
   connection_draining_timeout = "${var.connection_draining_timeout}"
 
-  security_groups    = ["${aws_security_group.vault.id}"]
-  subnets            = ["${var.subnet_ids}"]
+  security_groups = ["${aws_security_group.vault.id}"]
+  subnets         = ["${var.subnet_ids}"]
 
   # Run the ELB in TCP passthrough mode
   listener {
@@ -38,9 +38,7 @@ resource "aws_elb" "vault" {
     timeout             = "${var.health_check_timeout}"
   }
 
-  tags {
-    Name = "${var.name}"
-  }
+  tags = "${merge(map("Name", var.name), var.lb_tags)}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -110,3 +110,8 @@ variable "health_check_timeout" {
   description = "The amount of time, in seconds, before a health check times out."
   default     = 5
 }
+
+variable "lb_tags" {
+  description = "Tags to be applied to the load balancer."
+  default     = {}
+}


### PR DESCRIPTION
I am working on execution of the test suite but our accounts are locked down & preventing some of them from executing. I have, however, tested my change in our module's use of vault-elb.