### PR TITLE
Adding optional health_check_port variable to vault-elb

### DIFF
--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -31,7 +31,7 @@ resource "aws_elb" "vault" {
   }
 
   health_check {
-    target              = "${var.health_check_protocol}:${var.vault_api_port}${var.health_check_path}"
+    target              = "${var.health_check_protocol}:${var.health_check_port == 0 ? var.vault_api_port : var.health_check_port}${var.health_check_path}"
     interval            = "${var.health_check_interval}"
     healthy_threshold   = "${var.health_check_healthy_threshold}"
     unhealthy_threshold = "${var.health_check_unhealthy_threshold}"

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -91,6 +91,11 @@ variable "health_check_path" {
   default     = "/v1/sys/health?standbyok=true"
 }
 
+variable "health_check_port" {
+  description = "The port to use for health checks if not vault_api_port."
+  default     = 0
+}
+
 variable "health_check_interval" {
   description = "The amount of time, in seconds, between health checks."
   default     = 15


### PR DESCRIPTION
...so that vault-elb can, for instance, health check an 8201 LB against 8200

My cluster uses vault-elb to create a load-balancer for 8200 and a second LB for 8201. I want both health checks to hit 8200/sys/health. Thus the addition of this variable.
The new health_check_port defaults to zero which will cause vault_api_port to be used as before.