### PR TITLE
Allow installing vault enterprise

### DIFF
--- a/examples/vault-consul-ami/README.md
+++ b/examples/vault-consul-ami/README.md
@@ -28,27 +28,29 @@ To build the Vault and Consul AMI:
 
 1. Install [Packer](https://www.packer.io/).
 
-1. Configure your AWS credentials using one of the [options supported by the AWS 
+1. Configure your AWS credentials using one of the [options supported by the AWS
    SDK](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). Usually, the easiest option is to
    set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
 
-1. Use the [private-tls-cert module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/private-tls-cert) to generate a CA cert and public and private keys for a 
-   TLS cert: 
-   
-    1. Set the `dns_names` parameter to `vault.service.consul`. If you're using the [vault-cluster-public
-       example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and want a public domain name (e.g. `vault.example.com`), add that 
-       domain name here too.
-    1. Set the `ip_addresses` to `127.0.0.1`. 
-    1. For production usage, you should take care to protect the private key by encrypting it (see [Using TLS 
-       certs](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/private-tls-cert#using-tls-certs) for more info). 
+1. Use the [private-tls-cert module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/private-tls-cert) to generate a CA cert and public and private keys for a
+   TLS cert:
 
-1. Update the `variables` section of the `vault-consul.json` Packer template to specify the AWS region, Vault 
-   version, Consul version, and the paths to the TLS cert files you just generated. 
+    1. Set the `dns_names` parameter to `vault.service.consul`. If you're using the [vault-cluster-public
+       example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and want a public domain name (e.g. `vault.example.com`), add that
+       domain name here too.
+    1. Set the `ip_addresses` to `127.0.0.1`.
+    1. For production usage, you should take care to protect the private key by encrypting it (see [Using TLS
+       certs](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/private-tls-cert#using-tls-certs) for more info).
+
+1. Update the `variables` section of the `vault-consul.json` Packer template to specify the AWS region, Vault
+   version, Consul version, and the paths to the TLS cert files you just generated. If you want to install Consul Enterprise or Vault Enterprise,
+   skip the version variables and instead set the `consul_download_url` and `vault_download_url` to the full urls that point to the respective
+   enterprise zipped packages.
 
 1. Run `packer build vault-consul.json`.
 
-When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the 
-[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) and [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) 
+When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the
+[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) and [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public)
 examples.
 
 

--- a/examples/vault-consul-ami/vault-consul.json
+++ b/examples/vault-consul-ami/vault-consul.json
@@ -2,9 +2,11 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "vault_version": "0.10.0",
-    "consul_module_version": "v0.0.2",
-    "consul_version": "0.9.3",
+    "vault_version": "0.10.4",
+    "consul_module_version": "v0.3.7",
+    "consul_version": "1.2.2",
+    "consul_download_url": "",
+    "vault_download_url": "",
     "github_oauth_token": "{{env `GITHUB_OAUTH_TOKEN`}}",
     "ca_public_key_path": null,
     "tls_public_key_path": null,
@@ -57,7 +59,11 @@
   },{
     "type": "shell",
     "inline": [
-      "/tmp/terraform-aws-vault/modules/install-vault/install-vault --version {{user `vault_version`}}"
+      "if [[ -n '{{user `vault_download_url`}}' ]]; then",
+      " /tmp/terraform-aws-vault/modules/install-vault/install-vault --download-url {{user `vault_download_url`}};",
+      "else",
+      " /tmp/terraform-aws-vault/modules/install-vault/install-vault --version {{user `vault_version`}};",
+      "fi"
     ]
   },{
     "type": "file",
@@ -98,7 +104,11 @@
     "type": "shell",
     "inline": [
       "git clone --branch {{user `consul_module_version`}} https://{{user `github_oauth_token`}}@github.com/hashicorp/terraform-aws-consul.git /tmp/terraform-aws-consul",
-      "/tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}}",
+      "if [[ -n '{{user `consul_download_url`}}' ]]; then",
+      " /tmp/terraform-aws-consul/modules/install-consul/install-consul --download-url {{user `consul_download_url`}};",
+      "else",
+      " /tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}};",
+      "fi",
       "/tmp/terraform-aws-consul/modules/install-dnsmasq/install-dnsmasq"
     ]
   }]

--- a/modules/install-vault/README.md
+++ b/modules/install-vault/README.md
@@ -41,15 +41,15 @@ examples for fully-working sample code).
 
 The `install-vault` script accepts the following arguments:
 
-* `version VERSION`: Install Vault version VERSION. Required. 
+* `version VERSION`: Install Vault version VERSION. Optional if download-url is provided.
+* `download-url URL`: Install the Vault package hosted in this url. Optional if version is provided.
 * `path DIR`: Install Vault into folder DIR. Optional.
 * `user USER`: The install dirs will be owned by user USER. Optional.
-* `url URL`: Alternative url URL to download Vault from. Optional.
 
 Example:
 
 ```
-install-vault --version 0.10.0
+install-vault --version 0.10.4
 ```
 
 
@@ -58,16 +58,16 @@ install-vault --version 0.10.0
 
 The `install-vault` script does the following:
 
-1. [Create a user and folders for Vault](#create-a-user-and-folders-for-vault)
-1. [Install Vault binaries and scripts](#install-vault-binaries-and-scripts)
-1. [Configure mlock](#configure-mlock)
-1. [Install supervisord](#install-supervisord)
+1. [Creates a user and folders for Vault](#create-a-user-and-folders-for-vault)
+1. [Installs Vault binaries and scripts](#install-vault-binaries-and-scripts)
+1. [Configures mlock](#configure-mlock)
+1. [Installs supervisord](#install-supervisord)
 1. [Follow-up tasks](#follow-up-tasks)
 
 
-### Create a user and folders for Vault
+### Creates a user and folders for Vault
 
-Create an OS user named `vault`. Create the following folders, all owned by user `vault`:
+Creates an OS user named `vault`. Creates the following folders, all owned by user `vault`:
 
 * `/opt/vault`: base directory for Vault data (configurable via the `--path` argument).
 * `/opt/vault/bin`: directory for Vault binaries.
@@ -77,25 +77,26 @@ Create an OS user named `vault`. Create the following folders, all owned by user
 * `/opt/vault/tls`: directory where the Vault will look for TLS certs.
 
 
-### Install Vault binaries and scripts
+### Installs Vault binaries and scripts
 
-Install the following:
+Installs the following:
 
-* `vault`: Download the Vault zip file from the [downloads page](https://www.vaultproject.io/downloads.html) (the 
-  version number is configurable via the `--version` argument), and extract the `vault` binary into 
-  `/opt/vault/bin`. Add a symlink to the `vault` binary in `/usr/local/bin`.
-* `run-vault`: Copy the [run-vault script](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/run-vault) into `/opt/vault/bin`. 
+* `vault`: Either downloads the Vault zip file from the [downloads page](https://www.vaultproject.io/downloads.html) (the
+  version number is configurable via the `--version` argument) , or a package hosted on a precise url configurable with `--dowload-url`
+  (useful for installing Vault Enterprise, for example), and extracts the `vault` binary into `/opt/vault/bin`. Adds a
+  symlink to the `vault` binary in `/usr/local/bin`.
+* `run-vault`: Copies the [run-vault script](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/run-vault) into `/opt/vault/bin`.
 
 
-### Configure mlock
+### Configures mlock
 
-Give Vault permissions to make the `mlock` (memory lock) syscall. This syscall is used to prevent the OS from swapping
+Gives Vault permissions to make the `mlock` (memory lock) syscall. This syscall is used to prevent the OS from swapping
 Vault's memory to disk. For more info, see: https://www.vaultproject.io/docs/configuration/#disable_mlock.
 
 
-### Install supervisord
+### Installs supervisord
 
-Install [supervisord](http://supervisord.org/). We use it as a cross-platform supervisor to ensure Vault is started
+Installs [supervisord](http://supervisord.org/). We use it as a cross-platform supervisor to ensure Vault is started
 whenever the system boots and restarted if the Vault process crashes.
 
 

--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -10,6 +10,8 @@ set -e
 readonly DEFAULT_INSTALL_PATH="/opt/vault"
 readonly DEFAULT_VAULT_USER="vault"
 
+readonly DOWNLOAD_PACKAGE_PATH="/tmp/vault.zip"
+
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SYSTEM_BIN_DIR="/usr/local/bin"
 
@@ -26,14 +28,14 @@ function print_usage {
   echo
   echo "Options:"
   echo
-  echo -e "  --version\t\tThe version of Vault to install. Required."
+  echo -e "  --version\t\tThe version of Vault to install. Optional if download-url is provided."
+  echo -e "  --download-url\t\tUrl to exact Vault package to be installed. Optional if version is provided."
   echo -e "  --path\t\tThe path where Vault should be installed. Optional. Default: $DEFAULT_INSTALL_PATH."
   echo -e "  --user\t\tThe user who will own the Vault install directories. Optional. Default: $DEFAULT_VAULT_USER."
-  echo -e "  --url\t\t\tAlternative URL to download Vault from. Optional."
   echo
   echo "Example:"
   echo
-  echo "  install-vault --version 0.7.0"
+  echo "  install-vault --version 0.10.4"
 }
 
 function log {
@@ -64,6 +66,19 @@ function assert_not_empty {
 
   if [[ -z "$arg_value" ]]; then
     log_error "The value for '$arg_name' cannot be empty"
+    print_usage
+    exit 1
+  fi
+}
+
+function assert_either_or {
+  local readonly arg1_name="$1"
+  local readonly arg1_value="$2"
+  local readonly arg2_name="$3"
+  local readonly arg2_value="$4"
+
+  if [[ -z "$arg1_value" && -z "$arg2_value" ]]; then
+    log_error "Either the value for '$arg1_name' or '$arg2_name' must be passed, both cannot be empty"
     print_usage
     exit 1
   fi
@@ -181,22 +196,27 @@ function create_vault_install_paths {
   sudo chown -R "$username:$username" "$path"
 }
 
-function install_binaries {
+function fetch_binary {
   local readonly version="$1"
-  local readonly path="$2"
-  local readonly username="$3"
-  local readonly custom_url="$4"
+  local download_url="$2"
 
-  local readonly default_url="https://releases.hashicorp.com/vault/${version}/vault_${version}_linux_amd64.zip"
-  local readonly url=${custom_url:=$default_url}
-  local readonly download_path="/tmp/vault_${version}_linux_amd64.zip"
-  local readonly bin_dir="$path/bin"
+  if [[ -z "$download_url" && -n "$version" ]];  then
+    download_url="https://releases.hashicorp.com/vault/${version}/vault_${version}_linux_amd64.zip"
+  fi
+
+  log_info "Downloading Vault from $download_url to $DOWNLOAD_PACKAGE_PATH"
+  curl -o "$DOWNLOAD_PACKAGE_PATH" "$download_url" --location --silent --fail --show-error
+}
+
+function install_binary {
+  local readonly install_path="$1"
+  local readonly username="$2"
+
+  local readonly bin_dir="$install_path/bin"
   local readonly vault_dest_path="$bin_dir/vault"
   local readonly run_vault_dest_path="$bin_dir/run-vault"
 
-  log_info "Downloading Vault $version from $url to $download_path"
-  curl -o "$download_path" "$url"
-  unzip -d /tmp "$download_path"
+  unzip -d /tmp "$DOWNLOAD_PACKAGE_PATH"
 
   log_info "Moving Vault binary to $vault_dest_path"
   sudo mv "/tmp/vault" "$vault_dest_path"
@@ -225,9 +245,9 @@ function configure_mlock {
 
 function install {
   local version=""
+  local download_url=""
   local path="$DEFAULT_INSTALL_PATH"
   local user="$DEFAULT_VAULT_USER"
-  local url=""
 
   while [[ $# > 0 ]]; do
     local key="$1"
@@ -237,16 +257,16 @@ function install {
         version="$2"
         shift
         ;;
+      --download-url)
+        download_url="$2"
+        shift
+        ;;
       --path)
         path="$2"
         shift
         ;;
       --user)
         user="$2"
-        shift
-        ;;
-      --url)
-        url="$2"
         shift
         ;;
       --help)
@@ -263,7 +283,7 @@ function install {
     shift
   done
 
-  assert_not_empty "--version" "$version"
+  assert_either_or "--version" "$version" "--download-url" "$download_url"
   assert_not_empty "--path" "$path"
   assert_not_empty "--user" "$user"
 
@@ -272,7 +292,8 @@ function install {
   install_dependencies
   create_vault_user "$user"
   create_vault_install_paths "$path" "$user"
-  install_binaries "$version" "$path" "$user" "$url"
+  fetch_binary "$version" "$download_url"
+  install_binary "$path" "$user"
   configure_mlock
 
   log_info "Vault install complete!"


### PR DESCRIPTION
* Bumps default vault, consul and consul-modul versions at the packer template
* Refactors install-vault script. It already allowed passing a url, but it was not explicit that it would supercede downloading a binary by the version from the releases page. So I updated to now have more parity with the consul-install module, 
* Allows passing consul and vault download urls to packer template
* Updates docs


@infosecgithub