### PR TITLE
Feature/launch template

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -29,10 +29,11 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   health_check_grace_period = "${var.health_check_grace_period}"
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
   tags = ["${concat(
+    var.cluster_extra_tags,
     list(
       map("key", var.cluster_tag_key, "value", var.cluster_name, "propagate_at_launch", true)
-    ),
-    var.cluster_extra_tags)
+      )
+    )
   }"]
 }
 
@@ -118,8 +119,9 @@ resource "aws_launch_template" "launch_template" {
     resource_type = "volume"
 
     tags = "${merge(
-      map("key", var.cluster_tag_key, "value", var.cluster_name),
-      var.volume_extra_tags)
+      var.volume_extra_tags,
+      map("key", var.cluster_tag_key, "value", var.cluster_name)
+      )
     }"
   }
   # Important note: whenever using a launch configuration with an auto scaling group, you must set
@@ -150,7 +152,7 @@ resource "aws_security_group" "lc_security_group" {
     create_before_destroy = true
   }
 
-  tags = "${merge(map("Name", var.cluster_name), var.security_group_tags)}"
+  tags = "${merge(var.security_group_tags, map("Name", var.cluster_name))}"
 }
 
 resource "aws_security_group_rule" "allow_ssh_inbound_from_cidr_blocks" {

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -1,5 +1,7 @@
 output "asg_name" {
-  value = "${aws_autoscaling_group.autoscaling_group.name}"
+  # This is safe because asg_launch_mechanism will only allow one of aws_autoscaling_group.autoscaling_group.*
+  # or aws_autoscaling_group.lt_autoscaling_group.* to be non-empty.
+  value = "${join("",concat(aws_autoscaling_group.autoscaling_group.*.name,aws_autoscaling_group.lt_autoscaling_group.*.name))}"
 }
 
 output "cluster_tag_key" {
@@ -11,11 +13,9 @@ output "cluster_tag_value" {
 }
 
 output "cluster_size" {
-  value = "${aws_autoscaling_group.autoscaling_group.desired_capacity}"
-}
-
-output "launch_template_name" {
-  value = "${aws_launch_template.launch_template.name}"
+  # This is safe because asg_launch_mechanism will only allow one of aws_autoscaling_group.autoscaling_group.*
+  # or aws_autoscaling_group.lt_autoscaling_group.* to be non-empty.
+  value = "${join("",concat(aws_autoscaling_group.autoscaling_group.*.desired_capacity,aws_autoscaling_group.lt_autoscaling_group.*.desired_capacity))}"
 }
 
 output "iam_role_arn" {

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -14,12 +14,8 @@ output "cluster_size" {
   value = "${aws_autoscaling_group.autoscaling_group.desired_capacity}"
 }
 
-output "launch_config_name" {
-  value = "${var.use_launch_template ? "" : aws_launch_configuration.launch_configuration.*.name[0]}"
-}
-
 output "launch_template_name" {
-  value = "${var.use_launch_template ? aws_launch_template.launch_template.*.name[0] : ""}"
+  value = "${aws_launch_template.launch_template.name}"
 }
 
 output "iam_role_arn" {

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -15,7 +15,11 @@ output "cluster_size" {
 }
 
 output "launch_config_name" {
-  value = "${aws_launch_configuration.launch_configuration.name}"
+  value = "${var.use_launch_template ? "" : aws_launch_configuration.launch_configuration.*.name[0]}"
+}
+
+output "launch_template_name" {
+  value = "${var.use_launch_template ? aws_launch_template.launch_template.*.name[0] : ""}"
 }
 
 output "iam_role_arn" {

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -198,19 +198,31 @@ variable "force_destroy_s3_bucket" {
   default     = false
 }
 
+# Launch Template Extensions
+
+variable "asg_launch_mechanism" {
+  description = "Select between launch_config-driven or launch_template-driven autoscaling group."
+  default     = "launch_config"
+}
+
 variable "launch_template_tags" {
   description = "A list of tags to add to the launch template."
   type        = "map"
   default     = {}
 }
 
+variable "root_volume_ebs_encryption" {
+  description = "If true, the launched EC2 instance's root volume will be encrypted."
+  default     = ""
+}
+
+variable "launch_template_version" {
+  default = "Launch template verison to be used by the autoscaling group."
+  default = "$Latest"
+}
+
 variable "volume_extra_tags" {
   description = "A list of additional tags to add to each Instance's volumes in the ASG. Only applicable when use_launch_template is true."
   type        = "map"
   default     = {}
-}
-
-variable "ebs_encryption" {
-  description = "Value of 'encrypted' attribute on the launch template's block device definition."
-  default     = false
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -5,49 +5,40 @@
 
 variable "cluster_name" {
   description = "The name of the Vault cluster (e.g. vault-stage). This variable is used to namespace all resources created by this module."
-  default = "fred"
 }
 
 variable "ami_id" {
   description = "The ID of the AMI to run in this cluster. Should be an AMI that had Vault installed and configured by the install-vault module."
-  default = "123"
 }
 
 variable "instance_type" {
   description = "The type of EC2 Instances to run for each node in the cluster (e.g. t2.micro)."
-  default = "t2.micro"
 }
 
 variable "vpc_id" {
   description = "The ID of the VPC in which to deploy the cluster"
-  default = "123"
 }
 
 variable "allowed_inbound_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Vault"
   type        = "list"
-  default = []
 }
 
 variable "allowed_inbound_security_group_ids" {
   description = "A list of security group IDs that will be allowed to connect to Vault"
   type        = "list"
-  default = []
 }
 
 variable "allowed_inbound_security_group_count" {
   description = "The number of entries in var.allowed_inbound_security_group_ids. Ideally, this value could be computed dynamically, but we pass this variable to a Terraform resource's 'count' property and Terraform requires that 'count' be computed with literals or data sources only."
-  default = 0
 }
 
 variable "user_data" {
   description = "A User Data script to execute while the server is booting. We recommend passing in a bash script that executes the run-vault script, which should have been installed in the AMI by the install-vault module."
-  default = "#!/bin/bash"
 }
 
 variable "cluster_size" {
   description = "The number of nodes to have in the cluster. We strongly recommend setting this to 3 or 5."
-  default = 1
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -207,9 +198,10 @@ variable "force_destroy_s3_bucket" {
   default     = false
 }
 
-variable "use_launch_template" {
-  description = "Use aws_launch_template resource instead of aws_launch_configuration. Enables volume_extra_tags."
-  default     = false
+variable "launch_template_tags" {
+  description = "A list of tags to add to the launch template."
+  type        = "map"
+  default     = {}
 }
 
 variable "volume_extra_tags" {
@@ -218,3 +210,7 @@ variable "volume_extra_tags" {
   default     = {}
 }
 
+variable "ebs_encryption" {
+  description = "Value of 'encrypted' attribute on the launch template's block device definition."
+  default     = false
+}

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -5,40 +5,49 @@
 
 variable "cluster_name" {
   description = "The name of the Vault cluster (e.g. vault-stage). This variable is used to namespace all resources created by this module."
+  default = "fred"
 }
 
 variable "ami_id" {
   description = "The ID of the AMI to run in this cluster. Should be an AMI that had Vault installed and configured by the install-vault module."
+  default = "123"
 }
 
 variable "instance_type" {
   description = "The type of EC2 Instances to run for each node in the cluster (e.g. t2.micro)."
+  default = "t2.micro"
 }
 
 variable "vpc_id" {
   description = "The ID of the VPC in which to deploy the cluster"
+  default = "123"
 }
 
 variable "allowed_inbound_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Vault"
   type        = "list"
+  default = []
 }
 
 variable "allowed_inbound_security_group_ids" {
   description = "A list of security group IDs that will be allowed to connect to Vault"
   type        = "list"
+  default = []
 }
 
 variable "allowed_inbound_security_group_count" {
   description = "The number of entries in var.allowed_inbound_security_group_ids. Ideally, this value could be computed dynamically, but we pass this variable to a Terraform resource's 'count' property and Terraform requires that 'count' be computed with literals or data sources only."
+  default = 0
 }
 
 variable "user_data" {
   description = "A User Data script to execute while the server is booting. We recommend passing in a bash script that executes the run-vault script, which should have been installed in the AMI by the install-vault module."
+  default = "#!/bin/bash"
 }
 
 variable "cluster_size" {
   description = "The number of nodes to have in the cluster. We strongly recommend setting this to 3 or 5."
+  default = 1
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -197,3 +206,15 @@ variable "force_destroy_s3_bucket" {
   description = "If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true."
   default     = false
 }
+
+variable "use_launch_template" {
+  description = "Use aws_launch_template resource instead of aws_launch_configuration. Enables volume_extra_tags."
+  default     = false
+}
+
+variable "volume_extra_tags" {
+  description = "A list of additional tags to add to each Instance's volumes in the ASG. Only applicable when use_launch_template is true."
+  type        = "map"
+  default     = {}
+}
+


### PR DESCRIPTION
The goal of this PR is to allow the module user to select either launch_configuration (traditional) or launch_template. Selecting launch_template should be backward compatible with the original implementation but with the ability to propagate tags to instance volumes. (With the caveat described below.)

As usual, I can only test this with our particular usecases. In that internal testing (one VPC per region, two vault clusters per VPC) I have validated that the resulting instances are identical to their launch_configuration counterparts and that the instance volumes have the expected tags.

I have not yet implemented a similar change to terraform-aws-consul. Doing so may result in changes to this PR if new edgecases are discovered there.

Caveat:
It only works when encrypted == "". This was reportedly addressed by AWS provider 1.34.0 but I'm still having issues. Ref: https://github.com/terraform-providers/terraform-provider-aws/issues/4553
