### PR TITLE
adds optional variable for enabling specified autoscaling group metrics

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -28,6 +28,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   health_check_grace_period = "${var.health_check_grace_period}"
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
 
+  enabled_metrics = ["${var.enabled_metrics}"]
+
   # Use bucket and policies names in tags for depending on them when they are there
   # And only create the cluster after S3 bucket and policies exist
   # Otherwise Vault might boot and not find the bucket or not yet have the necessary permissions

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -207,3 +207,9 @@ variable "force_destroy_s3_bucket" {
   description = "If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true."
   default     = false
 }
+
+variable "enabled_metrics" {
+  description = "List of autoscaling group metrics to enable."
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
closes #112 

similar to https://github.com/hashicorp/terraform-aws-consul/pull/99 for terraform-aws-consul

this allows someone to **optionally** enable specified autoscaling group metrics