### PR TITLE
allow vault servers by default

### DIFF
--- a/examples/vault-auto-unseal/main.tf
+++ b/examples/vault-auto-unseal/main.tf
@@ -114,6 +114,9 @@ module "consul_cluster" {
   vpc_id     = "${data.aws_vpc.default.id}"
   subnet_ids = "${data.aws_subnet_ids.default.ids}"
 
+  allowed_inbound_security_group_ids   = ["${module.vault_cluster.security_group_id}"]
+  allowed_inbound_security_group_count = 1
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -103,6 +103,9 @@ module "consul_cluster" {
   vpc_id     = "${data.aws_vpc.default.id}"
   subnet_ids = "${data.aws_subnet_ids.default.ids}"
 
+  allowed_inbound_security_group_ids   = ["${module.vault_cluster.security_group_id}"]
+  allowed_inbound_security_group_count = 1
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 

--- a/examples/vault-ec2-auth/main.tf
+++ b/examples/vault-ec2-auth/main.tf
@@ -173,6 +173,9 @@ module "consul_cluster" {
   vpc_id     = "${data.aws_vpc.default.id}"
   subnet_ids = "${data.aws_subnet_ids.default.ids}"
 
+  allowed_inbound_security_group_ids   = ["${module.vault_cluster.security_group_id}"]
+  allowed_inbound_security_group_count = 1
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 

--- a/examples/vault-iam-auth/main.tf
+++ b/examples/vault-iam-auth/main.tf
@@ -233,6 +233,9 @@ module "consul_cluster" {
   vpc_id     = "${data.aws_vpc.default.id}"
   subnet_ids = "${data.aws_subnet_ids.default.ids}"
 
+  allowed_inbound_security_group_ids   = ["${module.vault_cluster.security_group_id}"]
+  allowed_inbound_security_group_count = 1
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -108,6 +108,9 @@ module "consul_cluster" {
   vpc_id     = "${data.aws_vpc.default.id}"
   subnet_ids = "${data.aws_subnet_ids.default.ids}"
 
+  allowed_inbound_security_group_ids   = ["${module.vault_cluster.security_group_id}"]
+  allowed_inbound_security_group_count = 1
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 

--- a/main.tf
+++ b/main.tf
@@ -184,6 +184,9 @@ module "consul_cluster" {
   vpc_id     = "${data.aws_vpc.default.id}"
   subnet_ids = "${data.aws_subnet_ids.default.ids}"
 
+  allowed_inbound_security_group_ids   = ["${module.vault_cluster.security_group_id}"]
+  allowed_inbound_security_group_count = 1
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
 


### PR DESCRIPTION
In production, it is recommended to restrict access. Here's a clean way
for Vault servers to access the Consul cluster