### PR TITLE
Replace backtick in run-vault with single quote

### DIFF
--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -35,7 +35,7 @@ function print_usage {
   echo -e "  --skip-vault-config\tIf this flag is set, don't generate a Vault configuration file. Optional. Default is false."
   echo -e "  --enable-s3-backend\tIf this flag is set, an S3 backend will be enabled in addition to the HA Consul backend. Default is false."
   echo -e "  --s3-bucket\tSpecifies the S3 bucket to use to store Vault data. Only used if '--enable-s3-backend' is set."
-  echo -e "  --s3-bucket-region\tSpecifies the AWS region where `--s3-bucket` lives. Only used if `--enable-s3-backend` is set."
+  echo -e "  --s3-bucket-region\tSpecifies the AWS region where '--s3-bucket' lives. Only used if '--enable-s3-backend' is set."
   echo
   echo "Optional Arguments for enabling the AWS KMS seal (Vault Enterprise or 1.0 and above):"
   echo


### PR DESCRIPTION
* Backticks causing unexpected behavior
* Removes backticks in favor of single quote to match other items in the
  list
* Credit to @BonzTM in #77 for initially finding/fixing; isolated to get
  fix merged