### PR TITLE
Fix/run vault

### DIFF
--- a/examples/vault-consul-ami/vault-consul.json
+++ b/examples/vault-consul-ami/vault-consul.json
@@ -2,7 +2,7 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "vault_version": "0.11.5",
+    "vault_version": "1.0.0",
     "consul_module_version": "v0.4.2",
     "consul_version": "1.3.1",
     "consul_download_url": "{{env `CONSUL_DOWNLOAD_URL`}}",

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -155,11 +155,17 @@ function generate_vault_config {
 
   local auto_unseal_config=""
   if [[ "$enable_auto_unseal" == "true" ]]; then
+
+    local endpoint=""
+    if [[ -n "$auto_unseal_endpoint" ]]; then
+      endpoint="endpoint   = '$auto_unseal_endpoint'"
+    fi
+
     auto_unseal_config=$(cat <<EOF
 seal "awskms" {
   kms_key_id = "$auto_unseal_kms_key_id"
   region     = "$auto_unseal_kms_key_region"
-  endpoint   = "$auto_unseal_endpoint"
+  $endpoint
 }\n
 EOF
 )

--- a/test/vault_cluster_autounseal_test.go
+++ b/test/vault_cluster_autounseal_test.go
@@ -1,0 +1,99 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/ssh"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
+)
+
+// This is the alias of a KMS key we have previously created that lives in the
+// AWS account where our CI tests run. We have one with the same alias in
+// every region. This key is necessary for the test of an Enterprise Vault feature
+// called auto unseal. If you wish to run test this locally, replace this with
+// the alias of an KMS key you already have on the AWS account you use for running
+// your tests or create a new one. Beware that creating an AWS KMS key costs money.
+const AUTO_UNSEAL_KMS_KEY_ALIAS = "dedicated-test-key"
+
+const VAULT_AUTO_UNSEAL_AUTH_PATH = "examples/vault-auto-unseal"
+const VAR_VAULT_AUTO_UNSEAL_KMS_KEY_ALIAS = "auto_unseal_kms_key_alias"
+
+// Test the Vault auto unseal example by:
+//
+// 1. Copying the code in this repo to a temp folder so tests on the Terraform code can run in parallel without the
+//    state files overwriting each other.
+// 2. Building the AMI in the vault-consul-ami example with the given build name
+// 3. Deploying a cluster of 1 vault server using the example Terraform code
+// 4. Sshing into vault node to initialize the server and check that it booted unsealed
+// 5. Increasing the the cluster size to 3 and check that new nodes are unsealed when they boot and join the cluster
+func runVaultAutoUnsealTest(t *testing.T, amiId string, awsRegion string, sshUserName string) {
+	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, VAULT_AUTO_UNSEAL_AUTH_PATH)
+
+	defer test_structure.RunTestStage(t, "teardown", func() {
+		teardownResources(t, examplesDir)
+	})
+
+	defer test_structure.RunTestStage(t, "log", func() {
+		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+		keyPair := test_structure.LoadEc2KeyPair(t, examplesDir)
+
+		getVaultLogs(t, "vaultAutoUnseal", terraformOptions, amiId, awsRegion, sshUserName, keyPair)
+	})
+
+	test_structure.RunTestStage(t, "deploy", func() {
+		uniqueId := random.UniqueId()
+		terraformVars := map[string]interface{}{
+			VAR_VAULT_AUTO_UNSEAL_KMS_KEY_ALIAS: AUTO_UNSEAL_KMS_KEY_ALIAS,
+			VAR_VAULT_CLUSTER_SIZE:              1,
+		}
+		deployCluster(t, amiId, awsRegion, examplesDir, uniqueId, terraformVars)
+	})
+
+	test_structure.RunTestStage(t, "validate", func() {
+		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+		keyPair := test_structure.LoadEc2KeyPair(t, examplesDir)
+
+		testAutoUnseal(t, OUTPUT_VAULT_CLUSTER_ASG_NAME, sshUserName, terraformOptions, awsRegion, keyPair)
+	})
+}
+
+func testAutoUnseal(t *testing.T, asgNameOutputVar string, sshUserName string, terraformOptions *terraform.Options, awsRegion string, keyPair *aws.Ec2Keypair) {
+	asgName := terraform.OutputRequired(t, terraformOptions, asgNameOutputVar)
+	nodeIpAddresses := getIpAddressesOfAsgInstances(t, asgName, awsRegion)
+	logger.Logf(t, fmt.Sprintf("IP ADDRESS OF INSTANCE %s", nodeIpAddresses[0]))
+	initialCluster := VaultCluster{
+		Leader: ssh.Host{
+			Hostname:    nodeIpAddresses[0],
+			SshUserName: sshUserName,
+			SshKeyPair:  keyPair.KeyPair,
+		},
+	}
+
+	establishConnectionToCluster(t, initialCluster)
+	waitForVaultToBoot(t, initialCluster)
+
+	retry.DoWithRetry(t, "Initializing the cluster", 10, 10*time.Second, func() (string, error) {
+		return ssh.CheckSshCommandE(t, initialCluster.Leader, "vault operator init")
+	})
+	assertStatus(t, initialCluster.Leader, Leader)
+
+	logger.Logf(t, "Increasing the cluster size and running 'terraform apply' again")
+	terraformOptions.Vars[VAR_VAULT_CLUSTER_SIZE] = 3
+	terraform.Apply(t, terraformOptions)
+
+	logger.Logf(t, "The cluster now should be bigger and the new nodes should boot unsealed (on standby mode already)")
+	newCluster := findVaultClusterNodes(t, asgNameOutputVar, sshUserName, terraformOptions, awsRegion, keyPair)
+	establishConnectionToCluster(t, newCluster)
+	for _, node := range newCluster.Nodes() {
+		if node.Hostname != initialCluster.Leader.Hostname {
+			assertStatus(t, node, Standby)
+		}
+	}
+}

--- a/test/vault_cluster_enterprise_test.go
+++ b/test/vault_cluster_enterprise_test.go
@@ -8,24 +8,12 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
-
-// This is the alias of a KMS key we have previously created that lives in the
-// AWS account where our CI tests run. We have one with the same alias in
-// every region. This key is necessary for the test of an Enterprise Vault feature
-// called auto unseal. If you wish to run test this locally, replace this with
-// the alias of an KMS key you already have on the AWS account you use for running
-// your tests or create a new one. Beware that creating an AWS KMS key costs money.
-const AUTO_UNSEAL_KMS_KEY_ALIAS = "dedicated-test-key"
-
-const VAULT_AUTO_UNSEAL_AUTH_PATH = "examples/vault-auto-unseal"
-const VAR_VAULT_AUTO_UNSEAL_KMS_KEY_ALIAS = "auto_unseal_kms_key_alias"
 
 // To test this on circle ci you need a url set as an environment variable, VAULT_AMI_TEMPLATE_VAR_DOWNLOAD_URL
 // which you would also have to set locally if you want to run this test locally.
@@ -36,45 +24,6 @@ func getUrlFromEnv(t *testing.T) string {
 		t.Fatalf("Please set the environment variable VAULT_AMI_TEMPLATE_VAR_DOWNLOAD_URL.\n")
 	}
 	return url
-}
-
-// Test the Vault auto unseal example by:
-//
-// 1. Copying the code in this repo to a temp folder so tests on the Terraform code can run in parallel without the
-//    state files overwriting each other.
-// 2. Building the AMI in the vault-consul-ami example with the given build name
-// 3. Deploying a cluster of 1 vault server using the example Terraform code
-// 4. Sshing into vault node to initialize the server and check that it booted unsealed
-// 5. Increasing the the cluster size to 3 and check that new nodes are unsealed when they boot and join the cluster
-func runVaultAutoUnsealTest(t *testing.T, amiId string, awsRegion string, sshUserName string) {
-	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, VAULT_AUTO_UNSEAL_AUTH_PATH)
-
-	defer test_structure.RunTestStage(t, "teardown", func() {
-		teardownResources(t, examplesDir)
-	})
-
-	defer test_structure.RunTestStage(t, "log", func() {
-		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
-		keyPair := test_structure.LoadEc2KeyPair(t, examplesDir)
-
-		getVaultLogs(t, "vaultAutoUnseal", terraformOptions, amiId, awsRegion, sshUserName, keyPair)
-	})
-
-	test_structure.RunTestStage(t, "deploy", func() {
-		uniqueId := random.UniqueId()
-		terraformVars := map[string]interface{}{
-			VAR_VAULT_AUTO_UNSEAL_KMS_KEY_ALIAS: AUTO_UNSEAL_KMS_KEY_ALIAS,
-			VAR_VAULT_CLUSTER_SIZE:              1,
-		}
-		deployCluster(t, amiId, awsRegion, examplesDir, uniqueId, terraformVars)
-	})
-
-	test_structure.RunTestStage(t, "validate", func() {
-		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
-		keyPair := test_structure.LoadEc2KeyPair(t, examplesDir)
-
-		testAutoUnseal(t, OUTPUT_VAULT_CLUSTER_ASG_NAME, sshUserName, terraformOptions, awsRegion, keyPair)
-	})
 }
 
 // Test the Vault enterprise cluster example by:
@@ -113,40 +62,6 @@ func runVaultEnterpriseClusterTest(t *testing.T, amiId string, awsRegion string,
 		testVaultUsesConsulForDns(t, cluster)
 		checkEnterpriseInstall(t, OUTPUT_VAULT_CLUSTER_ASG_NAME, sshUserName, terraformOptions, awsRegion, keyPair)
 	})
-}
-
-func testAutoUnseal(t *testing.T, asgNameOutputVar string, sshUserName string, terraformOptions *terraform.Options, awsRegion string, keyPair *aws.Ec2Keypair) {
-	asgName := terraform.OutputRequired(t, terraformOptions, asgNameOutputVar)
-	nodeIpAddresses := getIpAddressesOfAsgInstances(t, asgName, awsRegion)
-	logger.Logf(t, fmt.Sprintf("IP ADDRESS OF INSTANCE %s", nodeIpAddresses[0]))
-	initialCluster := VaultCluster{
-		Leader: ssh.Host{
-			Hostname:    nodeIpAddresses[0],
-			SshUserName: sshUserName,
-			SshKeyPair:  keyPair.KeyPair,
-		},
-	}
-
-	establishConnectionToCluster(t, initialCluster)
-	waitForVaultToBoot(t, initialCluster)
-
-	retry.DoWithRetry(t, "Initializing the cluster", 10, 10*time.Second, func() (string, error) {
-		return ssh.CheckSshCommandE(t, initialCluster.Leader, "vault operator init")
-	})
-	assertStatus(t, initialCluster.Leader, Leader)
-
-	logger.Logf(t, "Increasing the cluster size and running 'terraform apply' again")
-	terraformOptions.Vars[VAR_VAULT_CLUSTER_SIZE] = 3
-	terraform.Apply(t, terraformOptions)
-
-	logger.Logf(t, "The cluster now should be bigger and the new nodes should boot unsealed (on standby mode already)")
-	newCluster := findVaultClusterNodes(t, asgNameOutputVar, sshUserName, terraformOptions, awsRegion, keyPair)
-	establishConnectionToCluster(t, newCluster)
-	for _, node := range newCluster.Nodes() {
-		if node.Hostname != initialCluster.Leader.Hostname {
-			assertStatus(t, node, Standby)
-		}
-	}
 }
 
 // Check if the enterprise version of consul and vault is installed

--- a/test/vault_main_test.go
+++ b/test/vault_main_test.go
@@ -35,7 +35,7 @@ var testCases = []testCase{
 	{
 		"TestVaultAutoUnseal",
 		runVaultAutoUnsealTest,
-		true,
+		false,
 	},
 	{
 		"TestEnterpriseInstallation",


### PR DESCRIPTION
* Does not configure unseal endpoint unless a value is explicitly passed
* Tested using vault 1.0 and turns out tests are still passing and auto unseal works fine using the open source version, with the same previous example :) 