### PR TITLE
Use double quotes for unseal endpoint

### DIFF
--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -158,7 +158,7 @@ function generate_vault_config {
 
     local endpoint=""
     if [[ -n "$auto_unseal_endpoint" ]]; then
-      endpoint="endpoint   = '$auto_unseal_endpoint'"
+      endpoint="endpoint   = \"$auto_unseal_endpoint\""
     fi
 
     auto_unseal_config=$(cat <<EOF


### PR DESCRIPTION
Fixes `Error loading configuration from /opt/vault/config: error loading "/opt/vault/config/default.hcl": At 5:16: illegal char`

HCL does not support single quoting strings.