### PR TITLE
Add capability to enable S3 versioning for Vault backend

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -212,6 +212,10 @@ resource "aws_s3_bucket" "vault_storage" {
     var.s3_bucket_tags)
   }"
 
+  versioning {
+    enabled = "${var.enable_s3_bucket_versioning}"
+  }
+
   # aws_launch_configuration.launch_configuration in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
   # when you try to do a terraform destroy.

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -203,6 +203,11 @@ variable "s3_bucket_tags" {
   default     = {}
 }
 
+variable "enable_s3_bucket_versioning" {
+  description = "Whether to enable bucket versioning for the S3 bucket."
+  default     = false
+}
+
 variable "force_destroy_s3_bucket" {
   description = "If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true."
   default     = false


### PR DESCRIPTION
By using `enable_s3_bucket_versioning` you now enable bucket versioning
for the S3 backend.

This fixes #49.