### PR TITLE
Fixes to the docs

### DIFF
--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -1,25 +1,25 @@
-# Public Vault Cluster Example 
+# Public Vault Cluster Example
 
-This folder shows an example of Terraform code to deploy a [Vault](https://www.vaultproject.io/) cluster in 
-[AWS](https://aws.amazon.com/) using the [vault-cluster](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster) and [vault-elb](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-elb) 
-modules. The Vault cluster uses [Consul](https://www.consul.io/) as a storage backend, so this example also deploys a 
-separate Consul server cluster using the [consul-cluster 
-module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) from the Consul AWS 
+This folder shows an example of Terraform code to deploy a [Vault](https://www.vaultproject.io/) cluster in
+[AWS](https://aws.amazon.com/) using the [vault-cluster](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster) and [vault-elb](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-elb)
+modules. The Vault cluster uses [Consul](https://www.consul.io/) as a storage backend, so this example also deploys a
+separate Consul server cluster using the [consul-cluster
+module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) from the Consul AWS
 Module.
 
-This example creates a public Vault cluster that is accessible from the public Internet via an [Elastic Load Balancer 
+This example creates a public Vault cluster that is accessible from the public Internet via an [Elastic Load Balancer
 (ELB)](https://aws.amazon.com/elasticloadbalancing/classicloadbalancer/). For an example of a private Vault cluster
 that is accessible from inside the AWS account, see [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private).
 
 ![Vault architecture](https://github.com/hashicorp/terraform-aws-vault/blob/master/_docs/architecture-elb.png?raw=true)
 
-You will need to create an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
-that has Vault and Consul installed, which you can do using the [vault-consul-ami example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami)).  
+You will need to create an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html)
+that has Vault and Consul installed, which you can do using the [vault-consul-ami example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami)).
 
 For more info on how the Vault cluster works, check out the [vault-cluster](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster) documentation.
 
-**Note**: To keep this example as simple to deploy and test as possible, it deploys the Vault cluster into your default 
-VPC and default subnets, all of which are publicly accessible. This is OK for learning and experimenting, but for 
+**Note**: To keep this example as simple to deploy and test as possible, it deploys the Vault cluster into your default
+VPC and default subnets, all of which are publicly accessible. This is OK for learning and experimenting, but for
 production usage, we strongly recommend deploying the Vault cluster into the private subnets of a custom VPC.
 
 
@@ -34,15 +34,16 @@ To deploy a Vault Cluster:
    example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) documentation for
    instructions. Make sure to note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
-1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of our
-   public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
+1. Open `variables.tf`, set the environment variables specified at the top of the file, and fill in any other variables
+   that don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of
+   our public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
    recommended for production use.
 1. Run `terraform init`.
 1. Run `terraform apply`.
 1. Run the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) to
    print out the IP addresses of the Vault servers and some example commands you can run to interact with the cluster:
-   `../vault-examples-helper/vault-examples-helper.sh`.
-   
-To see how to connect to the Vault cluster, initialize it, and start reading and writing secrets, head over to the 
+   `../vault-examples-helper/vault-examples-helper.sh`. **NOTE**: This script assumes that you have a valid SSH key set
+   for the variable `ssh_key_name`.
+
+To see how to connect to the Vault cluster, initialize it, and start reading and writing secrets, head over to the
 [How do you use the Vault cluster?](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster#how-do-you-use-the-vault-cluster) docs.

--- a/examples/vault-cluster-private/README.md
+++ b/examples/vault-cluster-private/README.md
@@ -15,7 +15,7 @@ Each of the servers in this example has [Dnsmasq](http://www.thekelleys.org.uk/d
 [install-dnsmasq module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq)) 
 which allows it to use the Consul server cluster for service discovery and thereby access Vault via DNS using the 
 domain name `vault.service.consul`. For an example of a Vault cluster
-that is publicly accessible, see [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public).
+that is publicly accessible, see [the root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example).
 
 ![Vault architecture](https://github.com/hashicorp/terraform-aws-vault/blob/master/_docs/architecture.png?raw=true)
 

--- a/examples/vault-consul-ami/README.md
+++ b/examples/vault-consul-ami/README.md
@@ -35,8 +35,8 @@ To build the Vault and Consul AMI:
 1. Use the [private-tls-cert module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/private-tls-cert) to generate a CA cert and public and private keys for a
    TLS cert:
 
-    1. Set the `dns_names` parameter to `vault.service.consul`. If you're using the [vault-cluster-public
-       example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and want a public domain name (e.g. `vault.example.com`), add that
+    1. Set the `dns_names` parameter to `vault.service.consul`. If you're using the [root
+       example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) and want a public domain name (e.g. `vault.example.com`), add that
        domain name here too.
     1. Set the `ip_addresses` to `127.0.0.1`.
     1. For production usage, you should take care to protect the private key by encrypting it (see [Using TLS

--- a/examples/vault-consul-ami/README.md
+++ b/examples/vault-consul-ami/README.md
@@ -15,7 +15,7 @@ same AMI to deploy a separate [Consul server cluster](https://www.consul.io/) by
 module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster). 
 
 Check out the [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) and 
-[vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) examples for working sample code. For more info on Vault 
+[the root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) examples for working sample code. For more info on Vault 
 installation and configuration, check out the [install-vault](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/install-vault) documentation.
 
 
@@ -50,8 +50,13 @@ To build the Vault and Consul AMI:
 1. Run `packer build vault-consul.json`.
 
 When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the
-[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) and [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public)
+[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) and [the root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example)
 examples.
+
+**NOTE**: This packer template will build two versions of the AMI - an Ubuntu version and Amazon Linux 2 version. You
+can restrict packer to only build one of them by using the `only` CLI arg. For example, to only build the Amazon Linux 2
+AMI, run `packer build -only amazon-linux-2-ami vault-consul.json`. You can use the parameter `ubuntu16-ami` for the
+ubuntu AMI.
 
 
 

--- a/examples/vault-examples-helper/README.md
+++ b/examples/vault-examples-helper/README.md
@@ -1,7 +1,7 @@
 # Vault Examples Helper
 
 This folder contains a helper script called `vault-examples-helper.sh` for working with the 
-[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) and [vault-clsuter-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) 
+[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) and [the root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) 
 examples. After running `terraform apply` on one of the examples, if you run  `vault-examples-helper.sh`, it will 
 automatically:
 

--- a/examples/vault-examples-helper/vault-examples-helper.sh
+++ b/examples/vault-examples-helper/vault-examples-helper.sh
@@ -198,7 +198,7 @@ function print_instructions {
   instructions+=("\nTo unseal your Vault cluster, SSH to each of the servers and run the unseal command with 3 of the 5 unseal keys:\n")
   for server_ip in "${server_ips[@]}"; do
     instructions+=("    ssh -i $ssh_key_name ubuntu@$server_ip")
-    instructions+=("    vault unseal (run this 3 times)\n")
+    instructions+=("    vault operator unseal (run this 3 times)\n")
   done
 
   local vault_elb_domain_name
@@ -210,12 +210,12 @@ function print_instructions {
   if [[ -z "$vault_elb_domain_name" ]]; then
     instructions+=("\nOnce your cluster is unsealed, you can read and write secrets by SSHing to any of the servers:\n")
     instructions+=("    ssh -i $ssh_key_name ubuntu@$server_ip")
-    instructions+=("    vault auth")
+    instructions+=("    vault login")
     instructions+=("    vault write secret/example value=secret")
     instructions+=("    vault read secret/example")
   else
     instructions+=("\nOnce your cluster is unsealed, you can read and write secrets via the ELB:\n")
-    instructions+=("    vault auth -address=https://$vault_elb_domain_name")
+    instructions+=("    vault login -address=https://$vault_elb_domain_name")
     instructions+=("    vault write -address=https://$vault_elb_domain_name secret/example value=secret")
     instructions+=("    vault read -address=https://$vault_elb_domain_name secret/example")
   fi

--- a/examples/vault-iam-auth/README.md
+++ b/examples/vault-iam-auth/README.md
@@ -39,8 +39,8 @@ of the Vault nodes.
    instructions. Make sure the `install_auth_signing_script` variable is `true`.
    Make sure to note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
-1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default. Put the AMI ID you previously took note into the `ami_id` variable.
+1. Open `variables.tf`, set the environment variables specified at the top of the file, and fill in any other variables
+   that don't have a default. Put the AMI ID you previously took note into the `ami_id` variable.
 1. Run `terraform init`.
 1. Run `terraform apply`.
 1. Run the [vault-examples-helper.sh script][examples_helper] to

--- a/examples/vault-s3-backend/README.md
+++ b/examples/vault-s3-backend/README.md
@@ -11,7 +11,7 @@ servers in this example has [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.h
 [install-dnsmasq module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq)) 
 which allows it to use the Consul server cluster for service discovery and thereby access Vault via DNS using the 
 domain name `vault.service.consul`. For an example of a Vault cluster
-that is publicly accessible, see [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public).
+that is publicly accessible, see [the root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example).
 
 ![Vault architecture](https://github.com/hashicorp/terraform-aws-vault/blob/master/_docs/architecture-with-s3.png?raw=true)
 

--- a/modules/install-vault/README.md
+++ b/modules/install-vault/README.md
@@ -31,7 +31,7 @@ We recommend running the `install-vault` script as part of a [Packer](https://ww
 Vault [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) (see the 
 [vault-consul-ami example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami) for sample code). You can then deploy the AMI across an Auto 
 Scaling Group using the [vault-cluster module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster) (see the 
-[vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) 
+[root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) and [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) 
 examples for fully-working sample code).
 
 

--- a/modules/run-vault/README.md
+++ b/modules/run-vault/README.md
@@ -44,7 +44,7 @@ options.  See the [`systemd.exec` man pages](https://www.freedesktop.org/softwar
 options, but note that the `file:path` option requires [systemd version >= 236](https://stackoverflow.com/a/48052152), which is not provided 
 in the base Ubuntu 16.04 and Amazon Linux 2 images.
 
-See the [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and
+See the [root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) and
 [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) examples for fully-working sample code.
 
 

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -68,7 +68,7 @@ Note the following parameters:
 
 You can find the other parameters in [vars.tf](vars.tf).
 
-Check out the [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and 
+Check out the [root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) and 
 [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) examples for working sample code.
 
 
@@ -78,7 +78,7 @@ Check out the [vault-cluster-public](https://github.com/hashicorp/terraform-aws-
 ## How do you use the Vault cluster?
 
 To use the Vault cluster, you will typically need to SSH to each of the Vault servers. If you deployed the
-[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) or [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) 
+[vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) or [the root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) 
 examples, the [vault-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh) will do the 
 tag lookup for you automatically (note, you must have the [AWS CLI](https://aws.amazon.com/cli/) and 
 [jq](https://stedolan.github.io/jq/) installed locally):
@@ -463,7 +463,7 @@ same cluster because:
    your memory consumption on each server.
 
 Check out the [Consul AWS Module](https://github.com/hashicorp/terraform-aws-consul) for how to deploy a Consul 
-server cluster in AWS. See the [vault-cluster-public](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) and 
+server cluster in AWS. See the [root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) and 
 [vault-cluster-private](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-private) examples for sample code that shows how to run both a
 Vault server cluster and Consul server cluster.
 

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -141,7 +141,7 @@ Now that you have the unseal keys, you can [unseal Vault](https://www.vaultproje
 having 3 out of the 5 administrators (or whatever your key shard threshold is) do the following:
 
 1. SSH to a Vault server.
-1. Run `vault unseal`.
+1. Run `vault operator unseal`.
 1. Enter the unseal key when prompted.
 1. Repeat for each of the other Vault servers.
 

--- a/modules/vault-elb/README.md
+++ b/modules/vault-elb/README.md
@@ -48,7 +48,7 @@ Note the following parameters:
 
 You can find the other parameters in [vars.tf](vars.tf).
 
-Check out the [vault-cluster-public example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public) for working sample code.
+Check out the [root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example) for working sample code.
 
 
 

--- a/test/README.md
+++ b/test/README.md
@@ -60,9 +60,9 @@ cd test
 go test -v -timeout 60m -run TestFoo
 ```
 
-### Special note on the vault-cluster-public test
+### Special note on the root-example test
 
-As part of the tests for the [vault-cluster-public example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-cluster-public), we try to connect to the
+As part of the tests for the [root example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example), we try to connect to the
 Vault cluster via its ELB. If you've configure the test to set up a Route 53 domain name for the ELB, the tests will
 try to talk to Vault via this domain name; otherwise, they will talk directly to the ELB's domain name, albeit with
 the TLS check disabled, as the TLS cert will not include the ELB's domain name (since that's generated dynamically).


### PR DESCRIPTION
I went through the exercise of trying out the root example and deploying a vault cluster. In the process I hit a few warnings about deprecated commands, so updated those in the docs and scripts. I also updated a few places in the quickstart that wasn't immediately obvious to me what to do.

1. Clear trailing whitespace where I can
1. Changed `vars.tf` to `variables.tf`
1. `vault-cluster-public` was renamed to `root-example`, but links weren't updated
1. `vault unseal` is deprecated in favor of `vault operator unseal`
1. `vault auth` for logging in is deprecated in favor of `vault login`
1. The example script fails if `ssh_key_name` is blank, so highlighted that in the root example docs.

Notes
- I could not get to use it in the end because I didn't configure TLS correctly. I didn't use a publicly accessible domain, so `vault login` failed.
- I didn't know the best way to address this, but the example script assumes ubuntu clusters. I ran the example using Amazon Linux 2 and when I was copy pasting the output I missed that it had used `ubuntu@` and was confused for a brief moment.