### PR TITLE
Add Vault agent configuration

### DIFF
--- a/examples/vault-agent/README.md
+++ b/examples/vault-agent/README.md
@@ -7,7 +7,9 @@ and thus you do not have to implement potentially complicated renewal logic your
 This example uses the [AWS IAM Auth Method][iam_auth] to authenticate, and builds upon the [`IAM` auth
 example][iam_example], creating the same Vault `example-role`.  The difference between that and this
 example is instead of using curl to access the Vault API to authenticate, this example uses
-Vault agent to authenticate.
+Vault agent to authenticate.  The authentication token is written to a file under the Vault agent
+install directory (by default, `/opt/vault/data/vault-token`), which only the `vault` user has access
+to after installation.
 
 **Note**: To keep this example as simple to deploy and test as possible and because we are
 focusing on authentication, it deploys the Vault cluster into your default VPC and default subnets,

--- a/examples/vault-agent/README.md
+++ b/examples/vault-agent/README.md
@@ -1,0 +1,53 @@
+# Vault agent example
+
+This example shows how to use Vault agent's [auto-auth][auto_auth] feature to authenticate
+to a [vault cluster][vault_cluster].  Vault agent automatically handles renewal and re-authentication
+and thus you do not have to implement potentially complicated renewal logic yourself.
+
+This example uses the [AWS IAM Auth Method][iam_auth] to authenticate, and builds upon the [`IAM` auth
+example][iam_example], creating the same Vault `example-role`.  The difference between that and this
+example is instead of using curl to access the Vault API to authenticate, this example uses
+Vault agent to authenticate.
+
+**Note**: To keep this example as simple to deploy and test as possible and because we are
+focusing on authentication, it deploys the Vault cluster into your default VPC and default subnets,
+ all of which are publicly accessible. This is OK for learning and experimenting, but for
+production usage, we strongly recommend deploying the Vault cluster into the private subnets
+of a custom VPC.
+
+## Running this example
+You will need to create an [Amazon Machine Image (AMI)][ami] that has both Vault and Consul
+installed, which you can do using the [vault-consul-ami example][vault_consul_ami]). All the EC2
+Instances in this example (including the EC2 Instance that authenticates to Vault) install
+[Dnsmasq][dnsmasq] (via the [install-dnsmasq module][dnsmasq_module]) so that all DNS queries
+for `*.consul` will be directed to the Consul Server cluster. Because Consul has knowledge of
+all the Vault nodes (and in some cases, of other services as well), this setup allows the EC2
+Instance to use Consul's DNS server for service discovery, and thereby to discover the IP addresses
+of the Vault nodes.
+
+
+### Quick start
+
+1. `git clone` this repo to your computer.
+1. Build a Vault and Consul AMI. See the [vault-consul-ami example][vault_consul_ami] documentation for
+   instructions. Make sure the `install_auth_signing_script` variable is `true`.
+   Make sure to note down the ID of the AMI.
+1. Install [Terraform](https://www.terraform.io/).
+1. Open `variables.tf`, set the environment variables specified at the top of the file, and fill in any other variables
+   that don't have a default. Put the AMI ID you previously took note into the `ami_id` variable.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. Run the [vault-examples-helper.sh script][examples_helper] to
+   print out the IP addresses of the Vault server and some example commands you can run to interact with the cluster:
+   `../vault-examples-helper/vault-examples-helper.sh`.
+1. Run `curl <auth-instance-ip>:8080` to check if the client instance is fetching the secret from Vault properly
+
+
+[auto_auth]: https://www.vaultproject.io/docs/agent/autoauth/index.html
+[dnsmasq_module]: https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq
+[dnsmasq]: http://www.thekelleys.org.uk/dnsmasq/doc.html
+[examples_helper]: https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-examples-helper/vault-examples-helper.sh
+[iam_auth]: https://www.vaultproject.io/docs/auth/aws.html#iam-auth-method
+[iam_example]: https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-iam-auth
+[vault_cluster]: https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster
+[vault_consul_ami]: https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami

--- a/examples/vault-agent/main.tf
+++ b/examples/vault-agent/main.tf
@@ -1,0 +1,274 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A VAULT SERVER CLUSTER AND A CONSUL SERVER CLUSTER IN AWS
+# This is an example of how to launch a vault cluster and then authenticate an instance to the cluster
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.11.0"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# INSTANCE THAT WILL AUTHENTICATE TO VAULT USING VAULT AGENT
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_instance" "example_auth_to_vault" {
+  ami           = "${var.ami_id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${data.aws_subnet_ids.default.ids[0]}"
+  key_name      = "${var.ssh_key_name}"
+
+  # Security group that opens the necessary ports for consul
+  # And security group that opens the port to our simple web server
+  security_groups = [
+    "${module.consul_cluster.security_group_id}",
+    "${aws_security_group.auth_instance.id}",
+  ]
+
+  user_data            = "${data.template_file.user_data_auth_client.rendered}"
+  iam_instance_profile = "${aws_iam_instance_profile.example_instance_profile.name}"
+
+  tags {
+    Name = "${var.auth_server_name}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATES A ROLE THAT IS ATTACHED TO THE INSTANCE
+# The arn of this AWS role is what the Vault server will use create the Vault Role
+# so it can validate login requests from resources with this role
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_iam_instance_profile" "example_instance_profile" {
+  path = "/"
+  role = "${aws_iam_role.example_instance_role.name}"
+}
+
+resource "aws_iam_role" "example_instance_role" {
+  name_prefix        = "${var.auth_server_name}-role"
+  assume_role_policy = "${data.aws_iam_policy_document.example_instance_role.json}"
+}
+
+data "aws_iam_policy_document" "example_instance_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# Adds policies necessary for running consul
+module "consul_iam_policies_for_client" {
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.4.0"
+
+  iam_role_id = "${aws_iam_role.example_instance_role.id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# THE USER DATA SCRIPT THAT WILL RUN ON THE INSTANCE
+# This script will run consul, which is used for discovering vault cluster
+# And perform the login operation
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "template_file" "user_data_auth_client" {
+  template = "${file("${path.module}/user-data-auth-client.sh")}"
+
+  vars {
+    consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
+    consul_cluster_tag_value = "${var.consul_cluster_name}"
+    example_role_name        = "${var.example_role_name}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ADDS A RULE TO OPEN PORT 8080 SINCE OUR EXAMPLE LAUNCHES A SIMPLE WEB SERVER
+# This is here just for automated tests, not something that should be done with prod
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "auth_instance" {
+  name        = "${var.auth_server_name}"
+  description = "Security group for ${var.auth_server_name}"
+  vpc_id      = "${data.aws_vpc.default.id}"
+}
+
+resource "aws_security_group_rule" "allow_inbound_api" {
+  type        = "ingress"
+  from_port   = "8080"
+  to_port     = "8080"
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.auth_instance.id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ADDS A POLICY TO THE VAULT CLUSTER ROLE SO VAULT CAN QUERY AWS IAM USERS AND ROLES
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy" "vault_iam" {
+  name   = "vault_iam"
+  role   = "${module.vault_cluster.iam_role_id}"
+  policy = "${data.aws_iam_policy_document.vault_iam.json}"
+}
+
+data "aws_iam_policy_document" "vault_iam" {
+  statement {
+    effect  = "Allow"
+    actions = ["iam:GetRole", "iam:GetUser"]
+
+    # List of arns it can query, for more security, it could be set to specific roles or user
+    # resources = ["${aws_iam_role.example_instance_role.arn}"]
+    resources = [
+      "arn:aws:iam::*:user/*",
+      "arn:aws:iam::*:role/*",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["sts:GetCallerIdentity"]
+    resources = ["*"]
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY THE VAULT SERVER CLUSTER
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "vault_cluster" {
+  # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "github.com/hashicorp/terraform-aws-consul.git/modules/vault-cluster?ref=v0.0.1"
+  source = "../../modules/vault-cluster"
+
+  cluster_name  = "${var.vault_cluster_name}"
+  cluster_size  = "${var.vault_cluster_size}"
+  instance_type = "${var.vault_instance_type}"
+
+  ami_id    = "${var.ami_id}"
+  user_data = "${data.template_file.user_data_vault_cluster.rendered}"
+
+  vpc_id     = "${data.aws_vpc.default.id}"
+  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+
+  # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
+  # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
+
+  allowed_ssh_cidr_blocks              = ["0.0.0.0/0"]
+  allowed_inbound_cidr_blocks          = ["0.0.0.0/0"]
+  allowed_inbound_security_group_ids   = []
+  allowed_inbound_security_group_count = 0
+  ssh_key_name                         = "${var.ssh_key_name}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ATTACH IAM POLICIES FOR CONSUL
+# To allow our Vault servers to automatically discover the Consul servers, we need to give them the IAM permissions from
+# the Consul AWS Module's consul-iam-policies module.
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "consul_iam_policies_servers" {
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.4.0"
+
+  iam_role_id = "${module.vault_cluster.iam_role_id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# THE USER DATA SCRIPT THAT WILL RUN ON EACH VAULT SERVER WHEN IT'S BOOTING
+# This script will configure and start Vault
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "template_file" "user_data_vault_cluster" {
+  template = "${file("${path.module}/user-data-vault.sh")}"
+
+  vars {
+    consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
+    consul_cluster_tag_value = "${var.consul_cluster_name}"
+    example_role_name        = "${var.example_role_name}"
+
+    # Please note that normally we would never pass a secret this way
+    # This is just for test purposes so we can verify that our example instance is authenticating correctly
+    example_secret = "${var.example_secret}"
+
+    aws_iam_role_arn = "${aws_iam_role.example_instance_role.arn}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PERMIT CONSUL SPECIFIC TRAFFIC IN VAULT CLUSTER
+# To allow our Vault servers consul agents to communicate with other consul agents and participate in the LAN gossip,
+# we open up the consul specific protocols and ports for consul traffic
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "security_group_rules" {
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.4.0"
+
+  security_group_id = "${module.vault_cluster.security_group_id}"
+
+  # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
+  # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
+
+  allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY THE CONSUL SERVER CLUSTER
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "consul_cluster" {
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.4.0"
+
+  cluster_name  = "${var.consul_cluster_name}"
+  cluster_size  = "${var.consul_cluster_size}"
+  instance_type = "${var.consul_instance_type}"
+
+  # The EC2 Instances will use these tags to automatically discover each other and form a cluster
+  cluster_tag_key   = "${var.consul_cluster_tag_key}"
+  cluster_tag_value = "${var.consul_cluster_name}"
+
+  ami_id    = "${var.ami_id}"
+  user_data = "${data.template_file.user_data_consul.rendered}"
+
+  vpc_id     = "${data.aws_vpc.default.id}"
+  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+
+  # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
+  # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
+
+  allowed_ssh_cidr_blocks     = ["0.0.0.0/0"]
+  allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
+  ssh_key_name                = "${var.ssh_key_name}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# THE USER DATA SCRIPT THAT WILL RUN ON EACH CONSUL SERVER WHEN IT'S BOOTING
+# This script will configure and start Consul
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "template_file" "user_data_consul" {
+  template = "${file("${path.module}/user-data-consul.sh")}"
+
+  vars {
+    consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
+    consul_cluster_tag_value = "${var.consul_cluster_name}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY THE CLUSTERS IN THE DEFAULT VPC AND AVAILABILITY ZONES
+# Using the default VPC and subnets makes this example easy to run and test, but it means Consul and Vault are
+# accessible from the public Internet. In a production deployment, we strongly recommend deploying into a custom VPC
+# and private subnets.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc" "default" {
+  default = "${var.vpc_id == "" ? true : false}"
+  id      = "${var.vpc_id}"
+}
+
+data "aws_subnet_ids" "default" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+data "aws_region" "current" {}

--- a/examples/vault-agent/outputs.tf
+++ b/examples/vault-agent/outputs.tf
@@ -1,0 +1,95 @@
+output "auth_client_public_ip" {
+  value = "${aws_instance.example_auth_to_vault.public_ip}"
+}
+
+output "auth_client_instance_id" {
+  value = "${aws_instance.example_auth_to_vault.id}"
+}
+
+output "auth_role_arn" {
+  value = "${aws_iam_role.example_instance_role.arn}"
+}
+
+output "asg_name_vault_cluster" {
+  value = "${module.vault_cluster.asg_name}"
+}
+
+output "launch_config_name_vault_cluster" {
+  value = "${module.vault_cluster.launch_config_name}"
+}
+
+output "iam_role_arn_vault_cluster" {
+  value = "${module.vault_cluster.iam_role_arn}"
+}
+
+output "iam_role_id_vault_cluster" {
+  value = "${module.vault_cluster.iam_role_id}"
+}
+
+output "security_group_id_vault_cluster" {
+  value = "${module.vault_cluster.security_group_id}"
+}
+
+output "asg_name_consul_cluster" {
+  value = "${module.consul_cluster.asg_name}"
+}
+
+output "launch_config_name_consul_cluster" {
+  value = "${module.consul_cluster.launch_config_name}"
+}
+
+output "iam_role_arn_consul_cluster" {
+  value = "${module.consul_cluster.iam_role_arn}"
+}
+
+output "iam_role_id_consul_cluster" {
+  value = "${module.consul_cluster.iam_role_id}"
+}
+
+output "security_group_id_consul_cluster" {
+  value = "${module.consul_cluster.security_group_id}"
+}
+
+output "aws_region" {
+  value = "${data.aws_region.current.name}"
+}
+
+output "vault_servers_cluster_tag_key" {
+  value = "${module.vault_cluster.cluster_tag_key}"
+}
+
+output "vault_servers_cluster_tag_value" {
+  value = "${module.vault_cluster.cluster_tag_value}"
+}
+
+output "ssh_key_name" {
+  value = "${var.ssh_key_name}"
+}
+
+output "vault_cluster_size" {
+  value = "${var.vault_cluster_size}"
+}
+
+output "launch_config_name_servers" {
+  value = "${module.consul_cluster.launch_config_name}"
+}
+
+output "iam_role_arn_servers" {
+  value = "${module.consul_cluster.iam_role_arn}"
+}
+
+output "iam_role_id_servers" {
+  value = "${module.consul_cluster.iam_role_id}"
+}
+
+output "security_group_id_servers" {
+  value = "${module.consul_cluster.security_group_id}"
+}
+
+output "consul_cluster_cluster_tag_key" {
+  value = "${module.consul_cluster.cluster_tag_key}"
+}
+
+output "consul_cluster_cluster_tag_value" {
+  value = "${module.consul_cluster.cluster_tag_value}"
+}

--- a/examples/vault-agent/user-data-auth-client.sh
+++ b/examples/vault-agent/user-data-auth-client.sh
@@ -2,9 +2,10 @@
 # This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
 # run-consul script to configure and start Consul in client mode. Note that this script assumes it's running in an AMI
 # built from the Packer template in examples/vault-consul-ami/vault-consul.json.
-# It then uses a python script to create a signed request to the AWS STS API and sends this encrypted request
-# to the Vault server when authenticating. After login, it reads a secret and exposes it in a simple web server for
-# test purposes.
+# It then uses Vault agent to automatically authenticate to the Vault server. After login, Vault agent writes the
+# authentication token to a file location, which you can use for your applications.  Note that by default, only the `vault`
+# user has access to the file, so you may need to grant the appropriate permissions to your application.
+# Finally, this script reads a secret and exposes it in a simple web server for test purposes.
 
 set -e
 

--- a/examples/vault-agent/user-data-auth-client.sh
+++ b/examples/vault-agent/user-data-auth-client.sh
@@ -52,8 +52,9 @@ function retry {
 # Start the Vault agent
 /opt/vault/bin/run-vault --agent --agent-auth-type iam --agent-auth-role "${example_role_name}"
 
-# Retry in case the Vault server is still booting and unsealing
-# Or in case run-consul running on the background didn't finish yet
+# Retry and wait for the Vault Agent to write the token out to a file.  This could be
+# because the Vault server is still booting and unsealing, or because run-consul
+# running on the background didn't finish yet
 retry \
   "[[ -s /opt/vault/data/vault-token ]] && echo 'vault token file created'" \
   "waiting for Vault agent to write out token to sink"

--- a/examples/vault-agent/user-data-auth-client.sh
+++ b/examples/vault-agent/user-data-auth-client.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
+# run-consul script to configure and start Consul in client mode. Note that this script assumes it's running in an AMI
+# built from the Packer template in examples/vault-consul-ami/vault-consul.json.
+# It then uses a python script to create a signed request to the AWS STS API and sends this encrypted request
+# to the Vault server when authenticating. After login, it reads a secret and exposes it in a simple web server for
+# test purposes.
+
+set -e
+
+# Send the log output from this script to user-data.log, syslog, and the console
+# From: https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+# Log the given message. All logs are written to stderr with a timestamp.
+function log {
+ local -r message="$1"
+ local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+ >&2 echo -e "$timestamp $message"
+}
+
+# A retry function that attempts to run a command a number of times and returns the output
+function retry {
+  local -r cmd="$1"
+  local -r description="$2"
+
+  for i in $(seq 1 30); do
+    log "$description"
+
+    # The boolean operations with the exit status are there to temporarily circumvent the "set -e" at the
+    # beginning of this script which exits the script immediatelly for error status while not losing the exit status code
+    output=$(eval "$cmd") && exit_status=0 || exit_status=$?
+    errors=$(echo "$output") | grep '^{' | jq -r .errors
+
+    log "$output"
+
+    if [[ $exit_status -eq 0 && -n "$output" && -z "$errors" ]]; then
+      echo "$output"
+      return
+    fi
+    log "$description failed. Will sleep for 10 seconds and try again."
+    sleep 10
+  done;
+
+  log "$description failed after 30 attempts."
+  exit $exit_status
+}
+
+# These variables are passed in via Terraform template interpolation
+/opt/consul/bin/run-consul --client --cluster-tag-key "${consul_cluster_tag_key}" --cluster-tag-value "${consul_cluster_tag_value}"
+
+# Start the Vault agent
+/opt/vault/bin/run-vault --agent --agent-auth-type iam --agent-auth-role "${example_role_name}"
+
+# Retry in case the Vault server is still booting and unsealing
+# Or in case run-consul running on the background didn't finish yet
+retry \
+  "[[ -s /opt/vault/data/vault-token ]] && echo 'vault token file created'" \
+  "waiting for Vault agent to write out token to sink"
+
+# We can then use the client token from the login output once login was successful
+token=$(cat /opt/vault/data/vault-token)
+
+# And use the token to perform operations on vault such as reading a secret
+# These is being retried because race conditions were causing this to come up null sometimes
+response=$(retry \
+  "curl --fail -H 'X-Vault-Token: $token' -X GET https://vault.service.consul:8200/v1/secret/example_gruntwork" \
+  "Trying to read secret from vault")
+
+# Vault cli alternative:
+# export VAULT_TOKEN=$token
+# export VAULT_ADDR=https://vault.service.consul:8200
+# /opt/vault/bin/vault read secret/example_gruntwork
+# Serves the answer in a web server so we can test that this auth client is
+# authenticating to vault and fetching data correctly
+echo $response | jq -r .data.the_answer > index.html
+python -m SimpleHTTPServer 8080 &

--- a/examples/vault-agent/user-data-consul.sh
+++ b/examples/vault-agent/user-data-consul.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
+# run-consul script to configure and start Consul in server mode. Note that this script assumes it's running in an AMI
+# built from the Packer template in examples/vault-consul-ami/vault-consul.json.
+
+set -e
+
+# Send the log output from this script to user-data.log, syslog, and the console
+# From: https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+# These variables are passed in via Terraform template interpolation
+/opt/consul/bin/run-consul --server --cluster-tag-key "${consul_cluster_tag_key}" --cluster-tag-value "${consul_cluster_tag_value}"

--- a/examples/vault-agent/user-data-vault.sh
+++ b/examples/vault-agent/user-data-vault.sh
@@ -120,7 +120,7 @@ EOF
   auth/aws/role/${example_role_name}\
   auth_type=iam \
   policies=example-policy \
-  max_ttl=500h \
+  max_ttl=24h \
   bound_iam_principal_arn=${aws_iam_role_arn}
 
 # ==========================================================================

--- a/examples/vault-agent/variables.tf
+++ b/examples/vault-agent/variables.tf
@@ -1,0 +1,80 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "ami_id" {
+  description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/vault-consul-ami/vault-consul.json."
+}
+
+variable "ssh_key_name" {
+  description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
+}
+
+variable "example_secret" {
+  description = "Example secret to be written into vault server"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "example_role_name" {
+  description = "The name of the vault role"
+  default     = "example-role"
+}
+
+variable "vault_cluster_name" {
+  description = "What to name the Vault server cluster and all of its associated resources"
+  default     = "vault-example"
+}
+
+variable "consul_cluster_name" {
+  description = "What to name the Consul server cluster and all of its associated resources"
+  default     = "consul-example"
+}
+
+variable "auth_server_name" {
+  description = "What to name the server authenticating to vault"
+  default     = "auth-example"
+}
+
+variable "vault_cluster_size" {
+  description = "The number of Vault server nodes to deploy. We strongly recommend using 3 or 5."
+  default     = 1
+}
+
+variable "consul_cluster_size" {
+  description = "The number of Consul server nodes to deploy. We strongly recommend using 3 or 5."
+  default     = 1
+}
+
+variable "vault_instance_type" {
+  description = "The type of EC2 Instance to run in the Vault ASG"
+  default     = "t2.micro"
+}
+
+variable "consul_instance_type" {
+  description = "The type of EC2 Instance to run in the Consul ASG"
+  default     = "t2.micro"
+}
+
+variable "consul_cluster_tag_key" {
+  description = "The tag the Consul EC2 Instances will look for to automatically discover each other and form a cluster."
+  default     = "consul-servers"
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC to deploy into. Leave an empty string to use the Default VPC in this region."
+  default     = ""
+}

--- a/examples/vault-consul-ami/vault-consul.json
+++ b/examples/vault-consul-ami/vault-consul.json
@@ -2,7 +2,7 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "vault_version": "1.0.0",
+    "vault_version": "1.1.0",
     "consul_module_version": "v0.4.2",
     "consul_version": "1.3.1",
     "consul_download_url": "{{env `CONSUL_DOWNLOAD_URL`}}",

--- a/examples/vault-ec2-auth/README.md
+++ b/examples/vault-ec2-auth/README.md
@@ -76,8 +76,10 @@ Before we try to authenticate, we must be sure that the Vault Server is configur
 properly and prepared to receive requests. First, we must make sure the Vault server
 has been initialized (using `vault operator init`) and unsealed (using `vault operator unseal`).
 Next, we must enable Vault to support the AWS auth method (using `vault auth enable aws`).
-Finally, we must define the correct Vault Policies and Roles to declare which IAM
-Principals will have access to which resources in Vault.
+After that, we enable the Vault kv secrets engine at the path `secret` (note that this engine
+was enabled by default in previous versions < 1.1.0).  Finally, we must define the correct
+Vault Policies and Roles to declare which IAM Principals will have access to which resources
+in Vault.
 
 [Policies][policies_doc] are rules that grant or forbid access and actions to certain paths in
 Vault. With one or more policies on hand, you can then finally create the authentication role.

--- a/examples/vault-ec2-auth/user-data-vault.sh
+++ b/examples/vault-ec2-auth/user-data-vault.sh
@@ -95,6 +95,11 @@ retry \
   "/opt/vault/bin/vault auth enable aws" \
   "Trying to enable aws auth"
 
+# Enable the kv secrets engine at path `secret`, since we are using Vault version >= 1.1.0
+retry \
+  "/opt/vault/bin/vault secrets enable -version=1 -path=secret kv" \
+  "Trying to enable key-value secrets engine"
+
 # Creates a policy that allows writing and reading from an "example_" prefix at "secret" backend
 /opt/vault/bin/vault policy write "example-policy" -<<EOF
 path "secret/example_*" {

--- a/examples/vault-iam-auth/README.md
+++ b/examples/vault-iam-auth/README.md
@@ -83,8 +83,10 @@ Before we try to authenticate, we must be sure that the Vault Server is configur
 properly and prepared to receive requests. First, we must make sure the Vault server
 has been initialized (using `vault operator init`) and unsealed (using `vault operator unseal`).
 Next, we must enable Vault to support the AWS auth method (using `vault auth enable aws`).
-Finally, we must define the correct Vault Policies and Roles to declare which IAM
-Principals will have access to which resources in Vault.
+After that, we enable the Vault kv secrets engine at the path `secret` (note that this engine
+was enabled by default in previous versions < 1.1.0).  Finally, we must define the correct
+Vault Policies and Roles to declare which IAM Principals will have access to which resources
+in Vault.
 
 [Policies][policies_doc] are rules that grant or forbid access and actions to certain paths in
 Vault. With one or more policies on hand, you can then finally create the authentication role.

--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -157,6 +157,7 @@ function create_vault_install_paths {
   sudo mkdir -p "$path/scripts"
   sudo chmod 755 "$path"
   sudo chmod 755 "$path/bin"
+  sudo chmod 755 "$path/data"
 
   log_info "Changing ownership of $path to $username"
   sudo chown -R "$username:$username" "$path"

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -326,11 +326,11 @@ function generate_systemd_config {
 
   local vault_description="HashiCorp Vault - A tool for managing secrets"
   local vault_command="server"
-  local vault_config_file_or_dir=$vault_config_dir  # Vault agent requires single file, but server can accept config dir.
+  local vault_config_file_or_dir="$vault_config_dir"  # Vault agent requires single file, but server can accept config dir.
   if [[ "$is_vault_agent" == "true" ]]; then
     vault_command="agent"
     vault_description="HashiCorp Vault Agent"
-    vault_config_file_or_dir=$config_path
+    vault_config_file_or_dir="$config_path"
   fi
 
   log_info "Creating systemd config file to run Vault in $systemd_config_path"

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -4,7 +4,12 @@
 set -e
 
 readonly VAULT_CONFIG_FILE="default.hcl"
+readonly VAULT_PID_FILE="vault-pid"
+readonly VAULT_TOKEN_FILE="vault-token"
 readonly SYSTEMD_CONFIG_PATH="/etc/systemd/system/vault.service"
+
+readonly DEFAULT_AGENT_VAULT_ADDRESS="vault.service.consul"
+readonly DEFAULT_AGENT_AUTH_MOUNT_PATH="auth/aws"
 
 readonly DEFAULT_PORT=8200
 readonly DEFAULT_LOG_LEVEL="info"
@@ -37,6 +42,18 @@ function print_usage {
   echo -e "  --enable-s3-backend\tIf this flag is set, an S3 backend will be enabled in addition to the HA Consul backend. Default is false."
   echo -e "  --s3-bucket\tSpecifies the S3 bucket to use to store Vault data. Only used if '--enable-s3-backend' is set."
   echo -e "  --s3-bucket-region\tSpecifies the AWS region where '--s3-bucket' lives. Only used if '--enable-s3-backend' is set."
+  echo
+  echo "Options for Vault Agent:"
+  echo
+  echo -e "  --agent\t\t\tIf set, run in Vault Agent mode.  If not set, run as a regular Vault server.  Optional."
+  echo -e "  --agent-vault-address\t\tThe hostname or IP address of the Vault server to connect to.  Optional. Default is $DEFAULT_AGENT_VAULT_ADDRESS"
+  echo -e "  --agent-vault-port\t\tThe port of the Vault server to connect to.  Optional. Default is $DEFAULT_PORT"
+  echo -e "  --agent-ca-cert-file\t\tSpecifies the path to a CA certificate to verify the Vault server's TLS certificate.  Optional."
+  echo -e "  --agent-client-cert-file\tSpecifies the path to a certificate to use for TLS authentication to the Vault server.  Optional."
+  echo -e "  --agent-client-key-file\tSpecifies the path to the private key for the client certificate used for TLS authentication to the Vault server.  Optional."
+  echo -e "  --agent-auth-mount-path\tThe Vault mount path to the auth method used for auto-auth.  Optional.  Defaults to $DEFAULT_AGENT_AUTH_MOUNT_PATH"
+  echo -e "  --agent-auth-type\t\tThe Vault AWS auth type to use for auto-auth.  Required.  Must be either iam or ec2"
+  echo -e "  --agent-auth-role\t\tThe Vault role to authenticate against.  Required."
   echo
   echo "Optional Arguments for enabling the AWS KMS seal (Vault Enterprise or 1.0 and above):"
   echo
@@ -132,6 +149,75 @@ function vault_version_at_least {
     else
       log_info "Vault 0.10.0 or greater is required for UI support."
   fi
+}
+
+function generate_vault_agent_config {
+  local -r config_dir="$1"
+  local -r data_dir="$2"
+  local -r vault_address="$3"
+  local -r vault_port="$4"
+  local -r ca_cert_file="$5"
+  local -r client_cert_file="$6"
+  local -r client_key_file="$7"
+  local -r auth_mount_path="$8"
+  local -r auth_type="$9"
+  local -r auth_role="${10}"
+
+  local -r config_path="$config_dir/$VAULT_CONFIG_FILE"
+
+  log_info "Creating default Vault Agent config file in $config_path"
+
+  local -r pid_config="pid_file   = \"$data_dir/$VAULT_PID_FILE\""
+
+  local ca_cert_config=""
+  if [[ ! -z $ca_cert_file ]]; then
+   ca_cert_config=$(cat <<EOF
+  ca_cert = "$ca_cert_file"\n
+EOF
+)
+  fi
+
+  local client_cert_config=""
+  if [[ ! -z $client_cert_file ]] && [[ ! -z $client_key_file ]]; then
+   client_cert_config=$(cat <<EOF
+  client_cert = "$client_cert_file"
+  client_key = "$client_key_file"\n
+EOF
+)
+  fi
+
+  local -r vault_config=$(cat <<EOF
+vault {
+  address = "https://$vault_address:$vault_port"
+$ca_cert_config
+$client_cert_config
+}\n
+EOF
+)
+
+  local -r auto_auth_config=$(cat <<EOF
+auto_auth {
+  method "aws" {
+    mount_path = "$auth_mount_path"
+    config = {
+      type = "$auth_type"
+      role = "$auth_role"
+    }
+  }
+
+  sink "file" {
+    config = {
+      path = "$data_dir/$VAULT_TOKEN_FILE"
+    }
+  }
+}\n
+EOF
+)
+  echo -e "$pid_config" > "$config_path"
+  echo -e "$vault_config" >> "$config_path"
+  echo -e "$auto_auth_config" >> "$config_path"
+
+  chown "$user:$user" "$config_path"
 }
 
 function generate_vault_config {
@@ -235,13 +321,23 @@ function generate_systemd_config {
   local -r vault_systemd_stdout="$5"
   local -r vault_systemd_stderr="$6"
   local -r vault_user="$7"
+  local -r is_vault_agent="$8"
   local -r config_path="$config_dir/$VAULT_CONFIG_FILE"
+
+  local vault_description="HashiCorp Vault - A tool for managing secrets"
+  local vault_command="server"
+  local vault_config_file_or_dir=$vault_config_dir  # Vault agent requires single file, but server can accept config dir.
+  if [[ "$is_vault_agent" == "true" ]]; then
+    vault_command="agent"
+    vault_description="HashiCorp Vault Agent"
+    vault_config_file_or_dir=$config_path
+  fi
 
   log_info "Creating systemd config file to run Vault in $systemd_config_path"
 
   local -r unit_config=$(cat <<EOF
 [Unit]
-Description="HashiCorp Vault - A tool for managing secrets"
+Description=\"$vault_description\"
 Documentation=https://www.vaultproject.io/docs/
 Requires=network-online.target
 After=network-online.target
@@ -263,7 +359,7 @@ AmbientCapabilities=CAP_IPC_LOCK
 Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
-ExecStart=$vault_bin_dir/vault server -config $vault_config_dir -log-level=$vault_log_level
+ExecStart=$vault_bin_dir/vault $vault_command -config $vault_config_file_or_dir -log-level=$vault_log_level
 ExecReload=/bin/kill --signal HUP \$MAINPID
 KillMode=process
 KillSignal=SIGINT
@@ -324,6 +420,15 @@ function run {
   local enable_s3_backend="false"
   local s3_bucket=""
   local s3_bucket_region=""
+  local agent="false"
+  local agent_vault_address="$DEFAULT_AGENT_VAULT_ADDRESS"
+  local agent_vault_port="$DEFAULT_PORT"
+  local agent_ca_cert_file=""
+  local agent_client_cert_file=""
+  local agent_client_key_file=""
+  local agent_auth_mount_path="$DEFAULT_AGENT_AUTH_MOUNT_PATH"
+  local agent_auth_type=""
+  local agent_auth_role=""
   local enable_auto_unseal="false"
   local auto_unseal_kms_key_id=""
   local auto_unseal_kms_key_region=""
@@ -401,6 +506,47 @@ function run {
         s3_bucket_region="$2"
         shift
         ;;
+      --agent)
+        agent="true"
+        ;;
+      --agent-vault-address)
+        assert_not_empty "$key" "$2"
+        agent_vault_address="$2"
+        shift
+        ;;
+      --agent-vault-port)
+        assert_not_empty "$key" "$2"
+        agent_vault_port="$2"
+        shift
+        ;;
+      --agent-ca-cert_file)
+        assert_not_empty "$key" "$2"
+        agent_ca_cert_file="$2"
+        shift
+        ;;
+      --agent-client-cert-file)
+        assert_not_empty "$key" "$2"
+        agent_client_cert_file="$2"
+        shift
+        ;;
+      --agent-client-key-file)
+        assert_not_empty "$key" "$2"
+        agent_client_key_file="$2"
+        shift
+        ;;
+      --agent-auth-mount-path)
+        assert_not_empty "$key" "$2"
+        agent_auth_mount_path="$2"
+        shift
+        ;;
+      --agent-auth-type)
+        agent_auth_type="$2"
+        shift
+        ;;
+      --agent-auth-role)
+        agent_auth_role="$2"
+        shift
+        ;;
       --enable-auto-unseal)
         enable_auto_unseal="true"
         ;;
@@ -430,12 +576,18 @@ function run {
     shift
   done
 
-  assert_not_empty "--tls-cert-file" "$tls_cert_file"
-  assert_not_empty "--tls-key-file" "$tls_key_file"
+  # Required flags
+  if [[ "$agent" == "true" ]]; then
+    assert_not_empty "--agent-auth-type" "$agent_auth_type"
+    assert_not_empty "--agent-auth-role" "$agent_auth_role"
+  else
+    assert_not_empty "--tls-cert-file" "$tls_cert_file"
+    assert_not_empty "--tls-key-file" "$tls_key_file"
 
-  if [[ "$enable_s3_backend" == "true" ]]; then
-    assert_not_empty "--s3-bucket" "$s3_bucket"
-    assert_not_empty "--s3-bucket-region" "$s3_bucket_region"
+    if [[ "$enable_s3_backend" == "true" ]]; then
+      assert_not_empty "--s3-bucket" "$s3_bucket"
+      assert_not_empty "--s3-bucket-region" "$s3_bucket_region"
+    fi
   fi
 
   assert_is_installed "systemctl"
@@ -453,6 +605,10 @@ function run {
     bin_dir=$(cd "$SCRIPT_DIR/../bin" && pwd)
   fi
 
+  if [[ -z "$data_dir" ]]; then
+    data_dir=$(cd "$SCRIPT_DIR/../data" && pwd)
+  fi
+
   if [[ -z "$user" ]]; then
     user=$(get_owner_of_path "$config_dir")
   fi
@@ -465,7 +621,7 @@ function run {
     api_addr="https://$(get_instance_ip_address):${port}"
   fi
 
-  if [[ "$enable_auto_unseal" == "true" ]]; then
+  if [[ "$agent" == "false" ]] && [[ "$enable_auto_unseal" == "true" ]]; then
     log_info "The --enable-auto-unseal flag is set to true"
     assert_not_empty "--auto-unseal-kms-key-id" "$auto_unseal_kms_key_id"
     assert_not_empty "--auto-unseal-kms-key-region" "$auto_unseal_kms_key_region"
@@ -474,24 +630,40 @@ function run {
   if [[ "$skip_vault_config" == "true" ]]; then
     log_info "The --skip-vault-config flag is set, so will not generate a default Vault config file."
   else
-    generate_vault_config \
-      "$tls_cert_file" \
-      "$tls_key_file" \
-      "$port" \
-      "$cluster_port" \
-      "$api_addr" \
-      "$config_dir" \
-      "$user" \
-      "$enable_s3_backend" \
-      "$s3_bucket" \
-      "$s3_bucket_region" \
-      "$enable_auto_unseal" \
-      "$auto_unseal_kms_key_id" \
-      "$auto_unseal_kms_key_region" \
-      "$auto_unseal_endpoint"
+    if [[ "$agent" == "true" ]]; then
+      log_info "Running as Vault agent (--agent flag is set)"
+      generate_vault_agent_config \
+        "$config_dir" \
+        "$data_dir" \
+        "$agent_vault_address" \
+        "$agent_vault_port" \
+        "$agent_ca_cert_file" \
+        "$agent_client_cert_file" \
+        "$agent_client_key_file" \
+        "$agent_auth_mount_path" \
+        "$agent_auth_type" \
+        "$agent_auth_role"
+    else
+      log_info "Running as Vault server"
+      generate_vault_config \
+        "$tls_cert_file" \
+        "$tls_key_file" \
+        "$port" \
+        "$cluster_port" \
+        "$api_addr" \
+        "$config_dir" \
+        "$user" \
+        "$enable_s3_backend" \
+        "$s3_bucket" \
+        "$s3_bucket_region" \
+        "$enable_auto_unseal" \
+        "$auto_unseal_kms_key_id" \
+        "$auto_unseal_kms_key_region" \
+        "$auto_unseal_endpoint"
+    fi
   fi
 
-  generate_systemd_config "$SYSTEMD_CONFIG_PATH" "$config_dir" "$bin_dir" "$log_level" "$systemd_stdout" "$systemd_stderr" "$user"
+  generate_systemd_config "$SYSTEMD_CONFIG_PATH" "$config_dir" "$bin_dir" "$log_level" "$systemd_stdout" "$systemd_stderr" "$user" "$agent"
   start_vault
 }
 

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -118,7 +118,7 @@ this data is known by Vault, so you **MUST** save it in a secure place immediate
 the unseal keys should ever be so close together. You should distribute each one to a different, trusted administrator
 for safe keeping in completely separate secret stores and NEVER store them all in the same place. 
 
-In fact, a better option is to initial Vault with [PGP, GPG, or 
+In fact, a better option is to initialize Vault with [PGP, GPG, or
 Keybase](https://www.vaultproject.io/docs/concepts/pgp-gpg-keybase.html) so that each unseal key is encrypted with a
 different user's public key. That way, no one, not even the operator running the `init` command can see all the keys
 in one place:
@@ -147,6 +147,16 @@ having 3 out of the 5 administrators (or whatever your key shard threshold is) d
 
 Once this process is complete, all the Vault servers will be unsealed and you will be able to start reading and writing
 secrets.
+
+
+### Setting up a secrets engine
+
+In previous versions of Vault (< 1.1.0), a key-value secrets engine was automatically mounted at the path `secret/`.  This
+module.  The examples in this module use versions >= 1.1.0 and thus mount a key-value secrets engine at `secret/` explicitly.
+
+```
+vault secrets enable -version=1 -path=secret kv
+```
 
 
 ### Connecting to the Vault cluster to read and write secrets

--- a/test/vault_cluster_auth_test.go
+++ b/test/vault_cluster_auth_test.go
@@ -19,6 +19,7 @@ import (
 
 const VAULT_EC2_AUTH_PATH = "examples/vault-ec2-auth"
 const VAULT_IAM_AUTH_PATH = "examples/vault-iam-auth"
+const VAULT_AGENT_PATH = "examples/vault-agent"
 
 const VAR_VAULT_AUTH_SERVER_NAME = "auth_server_name"
 const VAR_VAULT_SECRET_NAME = "example_secret"
@@ -84,6 +85,44 @@ func runVaultIAMAuthTest(t *testing.T, amiId string, awsRegion string, sshUserNa
 	defer test_structure.RunTestStage(t, "log", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
 		getSyslogs(t, terraformOptions, amiId, awsRegion, "vaultIamAuth")
+	})
+
+	test_structure.RunTestStage(t, "deploy", func() {
+		uniqueId := random.UniqueId()
+		terraformVars := map[string]interface{}{
+			VAR_VAULT_AUTH_SERVER_NAME: fmt.Sprintf("vault-auth-test-%s", uniqueId),
+			VAR_VAULT_IAM_AUTH_ROLE:    fmt.Sprintf("vault-auth-role-test-%s", uniqueId),
+			VAR_VAULT_SECRET_NAME:      exampleSecret,
+		}
+		deployCluster(t, amiId, awsRegion, examplesDir, uniqueId, terraformVars)
+	})
+
+	test_structure.RunTestStage(t, "validate", func() {
+		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+		testRequestSecret(t, terraformOptions, exampleSecret)
+	})
+}
+
+// Test the Vault agent authentication example by:
+//
+// 1. Copying the code in this repo to a temp folder so tests on the Terraform code can run in parallel without the
+//    state files overwriting each other.
+// 2. Building the AMI in the vault-consul-ami example with the given build name
+// 3. Deploying that AMI using the example Terraform code setting an example secret
+// 4. Waiting for Vault to boot, then unsealing the server, creating a Vault Role to allow logins from resources with a specific AWS IAM Role and writing the example secret
+// 5. Waiting for the client to login, read the secret and launch a simple web server with the contents read
+// 6. Making a request to the webserver started by the auth client
+func runVaultAgentTest(t *testing.T, amiId string, awsRegion string, sshUserName string) {
+	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, VAULT_AGENT_PATH)
+	exampleSecret := "42"
+
+	defer test_structure.RunTestStage(t, "teardown", func() {
+		teardownResources(t, examplesDir)
+	})
+
+	defer test_structure.RunTestStage(t, "log", func() {
+		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+		getSyslogs(t, terraformOptions, amiId, awsRegion, "vaultAgentAuth")
 	})
 
 	test_structure.RunTestStage(t, "deploy", func() {

--- a/test/vault_main_test.go
+++ b/test/vault_main_test.go
@@ -67,6 +67,11 @@ var testCases = []testCase{
 		runVaultPublicClusterTest,
 		false,
 	},
+	{
+		"TestVaultAgent",
+		runVaultAgentTest,
+		false,
+	},
 }
 
 func TestMainVaultCluster(t *testing.T) {


### PR DESCRIPTION
Closes #133.  This adds support for installing as a Vault agent.  Currently, only auto-auth is supported (this doesn't add in support for caching).

I had to update to Vault 1.1.0, since it seems there was some bug with the Vault agent not respecting the Vault address in the config file.

I added a Vault agent test, which was mostly copy+pasted from the IAM auth test, with the only change being the use of Vault agent instead of hitting the Vault API using `curl`.

For testing, I only ran the Vault agent test using the Amazon Linux 2 image, and the EC2 Auth test using both the Amazon Linux 2 and Ubuntu images.