### PR TITLE
Enable vault in systemd

### DIFF
--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -395,6 +395,7 @@ EOF
 function start_vault {
   log_info "Reloading systemd config and starting Vault"
   sudo systemctl daemon-reload
+  sudo systemctl enable vault.service  
   sudo systemctl restart vault.service
 }
 


### PR DESCRIPTION
This ensures it starts back up automatically after a reboot! Thanks to @adriananeci for catching the same bug in https://github.com/hashicorp/terraform-aws-consul/pull/135.