### PR TITLE
Fix syntax of dynamic tag in block in ASG resource

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -62,9 +62,9 @@ resource "aws_autoscaling_group" "autoscaling_group" {
     for_each = var.cluster_extra_tags
 
     content {
-      key                 = tag.key
-      value               = tag.value
-      propagate_at_launch = tag.propagate_at_launch
+      key                 = tag.value.key
+      value               = tag.value.value
+      propagate_at_launch = tag.value.propagate_at_launch
     }
   }
 


### PR DESCRIPTION
The tag iterator object has a key and value attribute, it’s the value that’s needed to extract the actual key/value/propagate_at_launch attributes from.