### PR TITLE
fix broken link module

### DIFF
--- a/examples/vault-agent/main.tf
+++ b/examples/vault-agent/main.tf
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "vault_iam" {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "github.com/hashicorp/terraform-aws-consul.git/modules/vault-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
   cluster_name  = var.vault_cluster_name

--- a/examples/vault-auto-unseal/main.tf
+++ b/examples/vault-auto-unseal/main.tf
@@ -17,7 +17,7 @@ data "aws_kms_alias" "vault-example" {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "github.com/hashicorp/terraform-aws-consul.git/modules/vault-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
   cluster_name  = var.vault_cluster_name

--- a/examples/vault-ec2-auth/main.tf
+++ b/examples/vault-ec2-auth/main.tf
@@ -77,7 +77,7 @@ resource "aws_security_group_rule" "allow_inbound_api" {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "github.com/hashicorp/terraform-aws-consul.git/modules/vault-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
   cluster_name  = var.vault_cluster_name

--- a/examples/vault-iam-auth/main.tf
+++ b/examples/vault-iam-auth/main.tf
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "vault_iam" {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "github.com/hashicorp/terraform-aws-consul.git/modules/vault-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
   cluster_name  = var.vault_cluster_name

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -13,7 +13,7 @@ terraform {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "github.com/hashicorp/terraform-aws-consul.git/modules/vault-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
   cluster_name  = var.vault_cluster_name


### PR DESCRIPTION
Module vault cluster is under github.com/hashicorp/terraform-aws-vault.git and not github.com/hashicorp/terraform-aws-consul.git
