### PR TITLE
Pass IAM Instance profile ARN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,8 +66,6 @@ module "vault_cluster" {
   ami_id    = var.ami_id == null ? data.aws_ami.vault_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_vault_cluster.rendered
 
-  iam_instance_profile_arn = var.vault_iam_instance_profile_arn
-
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
 

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,8 @@ module "vault_cluster" {
   ami_id    = var.ami_id == null ? data.aws_ami.vault_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_vault_cluster.rendered
 
+  iam_instance_profile_arn = var.vault_iam_instance_profile_arn
+
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
 

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -313,7 +313,7 @@ Check out the [Security section](#security) for more details.
 ### IAM Role and Permissions
 
 Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached.
-The IAM Role ARN is exported as an output variable so you can add custom permissions. If you require a deterministic IAM role ARN, the `iam_instance_profile_arn` variable can be set to your desired IAM Instance profile ARN.
+If you wish to use an IAM role and IAM instance profile created outside of this module, you can pass the instance profile ARN in via the `iam_instance_profile_arn` variable.
 
 
 ### S3 bucket (Optional)

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -313,7 +313,7 @@ Check out the [Security section](#security) for more details.
 ### IAM Role and Permissions
 
 Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached.
-The IAM Role ARN is exported as an output variable so you can add custom permissions.
+The IAM Role ARN is exported as an output variable so you can add custom permissions. If you require a deterministic IAM role ARN, the `iam_instance_profile_arn` variable can be set to your desired IAM Instance profile ARN.
 
 
 ### S3 bucket (Optional)

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -203,6 +203,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_iam_instance_profile" "instance_profile" {
+  count       = var.iam_instance_profile_arn == null ? 1 : 0
   name_prefix = var.cluster_name
   path        = var.instance_profile_path
   role        = aws_iam_role.instance_role.name
@@ -216,6 +217,7 @@ resource "aws_iam_instance_profile" "instance_profile" {
 }
 
 resource "aws_iam_role" "instance_role" {
+  count              = var.iam_instance_profile_arn == null ? 1 : 0
   name_prefix        = var.cluster_name
   assume_role_policy = data.aws_iam_policy_document.instance_role.json
 
@@ -228,6 +230,8 @@ resource "aws_iam_role" "instance_role" {
 }
 
 data "aws_iam_policy_document" "instance_role" {
+  count = var.iam_instance_profile_arn == null ? 1 : 0
+
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -240,7 +244,7 @@ data "aws_iam_policy_document" "instance_role" {
 }
 
 resource "aws_s3_bucket" "vault_storage" {
-  count         = var.enable_s3_backend ? 1 : 0
+  count         = var.enable_s3_backend && var.iam_instance_profile_arn == null ? 1 : 0
   bucket        = var.s3_bucket_name
   force_destroy = var.force_destroy_s3_bucket
 
@@ -264,7 +268,7 @@ resource "aws_s3_bucket" "vault_storage" {
 }
 
 resource "aws_iam_role_policy" "vault_s3" {
-  count = var.enable_s3_backend ? 1 : 0
+  count = var.enable_s3_backend && var.iam_instance_profile_arn == null ? 1 : 0
   name  = "vault_s3"
   role  = aws_iam_role.instance_role.id
   policy = element(
@@ -281,7 +285,7 @@ resource "aws_iam_role_policy" "vault_s3" {
 }
 
 data "aws_iam_policy_document" "vault_s3" {
-  count = var.enable_s3_backend ? 1 : 0
+  count = var.enable_s3_backend && var.iam_instance_profile_arn == null ? 1 : 0
 
   statement {
     effect  = "Allow"
@@ -295,7 +299,7 @@ data "aws_iam_policy_document" "vault_s3" {
 }
 
 data "aws_iam_policy_document" "vault_auto_unseal_kms" {
-  count = var.enable_auto_unseal ? 1 : 0
+  count = var.enable_auto_unseal && var.iam_instance_profile_arn == null ? 1 : 0
 
   statement {
     effect = "Allow"
@@ -311,7 +315,7 @@ data "aws_iam_policy_document" "vault_auto_unseal_kms" {
 }
 
 resource "aws_iam_role_policy" "vault_auto_unseal_kms" {
-  count = var.enable_auto_unseal ? 1 : 0
+  count = var.enable_auto_unseal && var.iam_instance_profile_arn == null ? 1 : 0
   name  = "vault_auto_unseal_kms"
   role  = aws_iam_role.instance_role.id
   policy = element(

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -244,7 +244,7 @@ data "aws_iam_policy_document" "instance_role" {
 }
 
 resource "aws_s3_bucket" "vault_storage" {
-  count         = var.enable_s3_backend && var.iam_instance_profile_arn == null ? 1 : 0
+  count         = var.enable_s3_backend ? 1 : 0
   bucket        = var.s3_bucket_name
   force_destroy = var.force_destroy_s3_bucket
 

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -167,6 +167,11 @@ variable "health_check_grace_period" {
   default     = 300
 }
 
+variable "iam_instance_profile_arn" {
+  description = "The ARN of the IAM Instance profilee to use for the Vault instances'. Use this setting to ensure a deterministic IAM instance role ARN, otherwise the default will see terraform create a unique IAM instance profile name."
+  default     = ""
+}
+
 variable "instance_profile_path" {
   description = "Path in which to create the IAM instance profile."
   default     = "/"

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -168,7 +168,7 @@ variable "health_check_grace_period" {
 }
 
 variable "iam_instance_profile_arn" {
-  description = "The ARN of the IAM Instance profilee to use for the Vault instances'. Use this setting to ensure a deterministic IAM instance role ARN, otherwise the default will see terraform create a unique IAM instance profile name."
+  description = "The ARN of the IAM instance profile to use instead of having this module create one internally."
   default     = ""
 }
 

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -169,7 +169,8 @@ variable "health_check_grace_period" {
 
 variable "iam_instance_profile_arn" {
   description = "The ARN of the IAM instance profile to use instead of having this module create one internally."
-  default     = ""
+  type        = string
+  default     = null
 }
 
 variable "instance_profile_path" {

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,13 @@ variable "vault_instance_type" {
   default     = "t2.micro"
 }
 
+variable "vault_iam_instance_profile_arn" {
+  description = "The ARN of the IAM Instance profilee to use for the Vault instances'. Use this setting to ensure a deterministic IAM instance role ARN, otherwise the default will see terraform create a unique IAM instance profile name."
+  type        = "string"
+  default     = "null"
+}
+
+
 variable "consul_instance_type" {
   description = "The type of EC2 Instance to run in the Consul ASG"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "vault_instance_type" {
 }
 
 variable "vault_iam_instance_profile_arn" {
-  description = "The ARN of the IAM Instance profilee to use for the Vault instances'. Use this setting to ensure a deterministic IAM instance role ARN, otherwise the default will see terraform create a unique IAM instance profile name."
+  description = "The ARN of the IAM instance profile to use instead of having this module create one internally."
   type        = "string"
   default     = "null"
 }


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

This PR pass in as variable `iam_instance_profile_arn` to let the consumer be able to define the ARN of an instance profile managed externally of the lifecycle of the vault module.

If the user passes in the IAM Instance Profile ARN then all the policies that must be associated with the IAM roles will be managed by the user externally.

In some organizations, all IAM resources are not managed along with the TF modules but externally. 