### PR TITLE
Reduce Packer flakiness by updating apt-get

### DIFF
--- a/examples/vault-consul-ami/vault-consul.json
+++ b/examples/vault-consul-ami/vault-consul.json
@@ -74,6 +74,11 @@
     "type": "shell",
     "inline": ["mkdir -p /tmp/terraform-aws-vault/modules"]
   },{
+    "type": "shell",
+    "inline": [
+      "sudo apt-get update"
+    ]
+  },{
     "type": "file",
     "source": "{{template_dir}}/../../modules/",
     "destination": "/tmp/terraform-aws-vault/modules",


### PR DESCRIPTION
I was seeing some flakiness, where some dependencies like `awscli` were failing to download on the image after a `packer build`

Updating `apt-get` seemed to fix the flakiness for me