### PR TITLE
Storage backends

### DIFF
--- a/examples/vault-dynamodb-backend/main.tf
+++ b/examples/vault-dynamodb-backend/main.tf
@@ -43,7 +43,7 @@ module "vault_cluster" {
   ssh_key_name                         = var.ssh_key_name
 
   enable_dynamo_backend = true
-  dynamo_table_name = var.dynamo_table_name
+  dynamo_table_name     = var.dynamo_table_name
 }
 
 data "template_file" "user_data_vault_cluster" {

--- a/examples/vault-dynamodb-backend/user-data-vault.sh
+++ b/examples/vault-dynamodb-backend/user-data-vault.sh
@@ -16,8 +16,11 @@ readonly VAULT_TLS_KEY_FILE="/opt/vault/tls/vault.key.pem"
 
 # The variables below are filled in via Terraform interpolation
 /opt/vault/bin/run-vault \
-  --enable-dynamo-backend \
+  --storage-backend "dynamodb" \
+  --ha-storage-backend "dynamodb" \
   --dynamo-table "${dynamo_table_name}" \
   --dynamo-region "${aws_region}" \
+  --dynamo-ha-table "${dynamo_table_name}" \
+  --dynamo-ha-region "${aws_region}" \
   --tls-cert-file "$VAULT_TLS_CERT_FILE" \
   --tls-key-file "$VAULT_TLS_KEY_FILE"

--- a/examples/vault-s3-backend/user-data-vault.sh
+++ b/examples/vault-s3-backend/user-data-vault.sh
@@ -16,4 +16,4 @@ readonly VAULT_TLS_KEY_FILE="/opt/vault/tls/vault.key.pem"
 
 # The variables below are filled in via Terraform interpolation
 /opt/consul/bin/run-consul --client --cluster-tag-key "${consul_cluster_tag_key}" --cluster-tag-value "${consul_cluster_tag_value}"
-/opt/vault/bin/run-vault --tls-cert-file "$VAULT_TLS_CERT_FILE"  --tls-key-file "$VAULT_TLS_KEY_FILE" --enable-s3-backend --s3-bucket "${s3_bucket_name}" --s3-bucket-region "${aws_region}"
+/opt/vault/bin/run-vault --tls-cert-file "$VAULT_TLS_CERT_FILE"  --tls-key-file "$VAULT_TLS_KEY_FILE" --storage-backend "s3" --s3-bucket "${s3_bucket_name}" --s3-bucket-region "${aws_region}"

--- a/modules/run-vault/README.md
+++ b/modules/run-vault/README.md
@@ -72,10 +72,15 @@ The `run-vault` script accepts the following arguments:
 * `user` (optional): The user to run Vault as. Default is to use the owner of `config-dir`.
 * `skip-vault-config` (optional): If this flag is set, don't generate a Vault configuration file. This is useful if you
   have a custom configuration file and don't want to use any of of the default settings from `run-vault`.
-* `--enable-s3-backend` (optional): If this flag is set, an S3 backend will be enabled in addition to the HA Consul backend.
-* `--s3-bucket` (optional): Specifies the S3 bucket to use to store Vault data. Only used if `--enable-s3-backend` is set.
-* `--s3-bucket-path` (optional): Specifies the S3 bucket path to use to store Vault data. Default is `""`. Only used if `--enable-s3-backend` is set.
-* `--s3-bucket-region` (optional): Specifies the AWS region where `--s3-bucket` lives. Only used if `--enable-s3-backend` is set.
+* `--storage-backend` (optional): If this flag is set, the backend will be enabled in addition to the HA backend. Default is `consul`.
+* `--ha-storage-backend` (optional): If this flag is set, the HA backend will be enabled in addition to the storage backend. Default is `consul`.
+* `--s3-bucket` (optional): Specifies the S3 bucket to use to store Vault data. Only used if `--storage-backend` is set to `s3`.
+* `--s3-bucket-path` (optional): Specifies the S3 bucket path to use to store Vault data. Default is `""`. Only used if `--storage-backend` is set to `s3`.
+* `--s3-bucket-region` (optional): Specifies the AWS region where `--s3-bucket` lives. Only used if `--storage-backend` is set to `s3`.
+* `--dynamo-region` (optional): Specifies the AWS region where `--dynamo-table` lives. Only used if `--storage-backend` is set to `dynamodb`.
+* `--dynamo-table` (optional): Specifies the DynamoDB table name. Only used if `--storage-backend` is set to `dynamodb`.
+* `--dynamo-ha-region` (optional): Specifies the AWS region where `--dynamo-table` lives. Only used if `--ha-storage-backend` is set to `dynamodb`.
+* `--dynamo-ha-table` (optional): Specifies the DynamoDB table name. Only used if `--ha-storage-backend` is set to `dynamodb`.
 
 Optional Arguments for enabling the AWS KMS seal (Vault Enterprise only):
  * `--enable-auto-unseal`: If this flag is set, enable the AWS KMS Auto-unseal feature. Default is false.
@@ -92,7 +97,7 @@ Example:
 Or if you want to enable an S3 backend:
 
 ```
-/opt/vault/bin/run-vault --tls-cert-file /opt/vault/tls/vault.crt.pem --tls-key-file /opt/vault/tls/vault.key.pem --enable-s3-backend --s3-bucket my-vault-bucket --s3-bucket-region us-east-1
+/opt/vault/bin/run-vault --tls-cert-file /opt/vault/tls/vault.crt.pem --tls-key-file /opt/vault/tls/vault.key.pem --storage-backend s3 --s3-bucket my-vault-bucket --s3-bucket-region us-east-1
 ```
 
 
@@ -145,8 +150,8 @@ available.
 
 `run-vault` can optionally set the following configuration values:
 
-* [storage](https://www.vaultproject.io/docs/configuration/index.html#storage): Set the `--enable-s3-backend` flag to
-  configure S3 as an additional (non-HA) storage backend with the following settings:
+* [storage- S3](https://www.vaultproject.io/docs/configuration/index.html#storage): Set the `--storage-backend` flag to
+  `s3` to configure S3 as an additional (non-HA) storage backend with the following settings:
 
     * [bucket](https://www.vaultproject.io/docs/configuration/storage/s3.html#bucket): Set to the `--s3-bucket`
       parameter.
@@ -154,6 +159,23 @@ available.
       parameter.
     * [region](https://www.vaultproject.io/docs/configuration/storage/s3.html#region): Set to the `--s3-bucket-region`
       parameter.
+
+* [storage - DynamoDB](https://www.vaultproject.io/docs/configuration/index.html#storage): Set the `--storage-backend` flag to
+  `dynamodb` to configure DynamoDB as an additional storage backend with the following settings:
+
+    * [table](https://www.vaultproject.io/docs/configuration/storage/dynamodb/#inlinecode-table-18): Set to the `--dynamo-table`
+      parameter.
+    * [region](https://www.vaultproject.io/docs/configuration/storage/dynamodb/#inlinecode-region-21): Set to the `--dynamo-region`
+      parameter.
+
+* [HA storage - DynamoDB](https://www.vaultproject.io/docs/configuration/index.html#storage): Set the `--ha-storage-backend` flag to
+  `dynamodb` to configure DynamoDB as an additional storage backend with the following settings:
+
+    * [ha-table](https://www.vaultproject.io/docs/configuration/storage/dynamodb/#inlinecode-table-18): Set to the `--dynamo-ha-table`
+      parameter for the HA storage.
+    * [ha-region](https://www.vaultproject.io/docs/configuration/storage/dynamodb/#inlinecode-region-21): Set to the `--dynamo-ha-region`
+      parameter for the HA storage.
+
 
 ### Overriding the configuration
 

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -39,13 +39,15 @@ function print_usage {
   echo -e "  --systemd-stderr\t\tThe StandardError option of the systemd unit.  Optional.  If not configured, uses systemd's default (inherit)."
   echo -e "  --user\t\tThe user to run Vault as. Optional. Default is to use the owner of --config-dir."
   echo -e "  --skip-vault-config\tIf this flag is set, don't generate a Vault configuration file. Optional. Default is false."
-  echo -e "  --enable-s3-backend\tIf this flag is set, an S3 backend will be enabled in addition to the HA Consul backend. Default is false."
-  echo -e "  --s3-bucket\tSpecifies the S3 bucket to use to store Vault data. Only used if '--enable-s3-backend' is set."
-  echo -e "  --s3-bucket-path\tSpecifies the S3 bucket path to use to store Vault data. Only used if '--enable-s3-backend' is set."
-  echo -e "  --s3-bucket-region\tSpecifies the AWS region where '--s3-bucket' lives. Only used if '--enable-s3-backend' is set."
-  echo -e "  --enable-dynamo-backend\tIf this flag is set, DynamoDB will be enabled as the backend storage (HA)"
-  echo -e "  --dynamo-region\tSpecifies the AWS region where --dynamo-table lives.  Only used if '--enable-dynamo-backend is on'"
-  echo -e "  --dynamo--table\tSpecifies the DynamoDB table to use for HA Storage.  Only used if '--enable-dynamo-backend is on'"
+  echo -e "  --storage-backend\tStorage backend type to use for secrets. Default is consul"
+  echo -e "  --ha-storage-backend\tStorage backend type to use for HA. Default is consul"
+  echo -e "  --s3-bucket\tSpecifies the S3 bucket to use to store Vault data. Only used if '--storage-backend' is s3"
+  echo -e "  --s3-bucket-path\tSpecifies the S3 bucket path to use to store Vault data. Only used if '--storage-backend' is s3"
+  echo -e "  --s3-bucket-region\tSpecifies the AWS region where '--s3-bucket' lives. Only used if '--storage-backend' is s3"
+  echo -e "  --dynamo-region\tSpecifies the AWS region where --dynamo-table lives.  Only used if '--storage-backend' is dynamodb"
+  echo -e "  --dynamo-table\tSpecifies the DynamoDB table to use for HA Storage.  Only used if '--storage-backend' is dynamodb"
+  echo -e "  --dynamo-ha-region\tSpecifies the AWS region where --dynamo-table lives.  Only used if '--ha-storage-backend' is dynamodb"
+  echo -e "  --dynamo-ha-table\tSpecifies the DynamoDB table to use for HA Storage.  Only used if '--ha-storage-backend' is dynamodb"
   echo
   echo "Options for Vault Agent:"
   echo
@@ -72,7 +74,7 @@ function print_usage {
   echo
   echo "Or"
   echo
-  echo "  run-vault --tls-cert-file /opt/vault/tls/vault.crt.pem --tls-key-file /opt/vault/tls/vault.key.pem --enable-s3-backend --s3-bucket my-vault-bucket --s3-bucket-region us-east-1"
+  echo "  run-vault --tls-cert-file /opt/vault/tls/vault.crt.pem --tls-key-file /opt/vault/tls/vault.key.pem --storage-backend s3 --s3-bucket my-vault-bucket --s3-bucket-region us-east-1"
 }
 
 function log {
@@ -232,17 +234,19 @@ function generate_vault_config {
   local -r api_addr="$5"
   local -r config_dir="$6"
   local -r user="$7"
-  local -r enable_s3_backend="$8"
-  local -r s3_bucket="$9"
-  local -r s3_bucket_path="${10}"
-  local -r s3_bucket_region="${11}"
-  local -r enable_dynamo_backend="${12}"
+  local -r storage_backend="${8}"
+  local -r ha_storage_backend="${9}"
+  local -r s3_bucket="${10}"
+  local -r s3_bucket_path="${11}"
+  local -r s3_bucket_region="${12}"
   local -r dynamo_region="${13}"
   local -r dynamo_table="${14}"
-  local -r enable_auto_unseal="${15}"
-  local -r auto_unseal_kms_key_id="${16}"
-  local -r auto_unseal_kms_key_region="${17}"
-  local -r auto_unseal_endpoint="${18}"
+  local -r dynamo_ha_region="${15}"
+  local -r dynamo_ha_table="${16}"
+  local -r enable_auto_unseal="${17}"
+  local -r auto_unseal_kms_key_id="${18}"
+  local -r auto_unseal_kms_key_region="${19}"
+  local -r auto_unseal_endpoint="${20}"
   local -r config_path="$config_dir/$VAULT_CONFIG_FILE"
 
   local instance_ip_address
@@ -282,13 +286,22 @@ listener "tcp" {
 }\n
 EOF
 )
-
-  local consul_storage_type="storage"
-  local dynamodb_storage_type="storage"
-  local s3_config=""
   local vault_storage_backend=""
-  if [[ "$enable_s3_backend" == "true" ]]; then
-    s3_config=$(cat <<EOF
+  local vault_ha_storage_backend=""
+  if [[ "$storage_backend" == "consul" ]]; then
+    vault_storage_backend=$(cat <<EOF
+storage "consul" {
+  address = "127.0.0.1:8500"
+  path    = "vault/"
+  scheme  = "http"
+  service = "vault"
+}\n
+EOF
+)
+  fi
+
+  if [[ "$storage_backend" == "s3" ]]; then
+    vault_storage_backend=$(cat <<EOF
 storage "s3" {
   bucket = "$s3_bucket"
   path   = "$s3_bucket_path"
@@ -296,44 +309,56 @@ storage "s3" {
 }\n
 EOF
 )
-    consul_storage_type="ha_storage"
-    dynamodb_storage_type="ha_storage"
   fi
 
-
-  if [[ "$enable_dynamo_backend" == "true" ]]; then
+  if [[ "$storage_backend" == "dynamodb" ]]; then
     vault_storage_backend=$(cat <<EOF
-$dynamodb_storage_type "dynamodb" {
-  ha_enabled = "true"
+storage "dynamodb" {
   region = "$dynamo_region"
   table  = "$dynamo_table"
-}
-# HA settings
-cluster_addr  = "https://$instance_ip_address:$cluster_port"
-api_addr      = "$api_addr"
+}\n
 EOF
 )
-  else
-    vault_storage_backend=$(cat <<EOF
-$consul_storage_type "consul" {
+  fi
+
+  if [[ "$ha_storage_backend" == "dynamodb" ]]; then
+    vault_ha_storage_backend=$(cat <<EOF
+ha_storage "dynamodb" {
+  ha_enabled = "true"
+  region = "$dynamo_ha_region"
+  table  = "$dynamo_ha_table"
+}\n
+EOF
+)
+  fi
+
+  if [[ "$ha_storage_backend" == "consul" ]]; then
+    vault_ha_storage_backend=$(cat <<EOF
+ha_storage "consul" {
   address = "127.0.0.1:8500"
   path    = "vault/"
   scheme  = "http"
   service = "vault"
-}
-# HA settings
-cluster_addr  = "https://$instance_ip_address:$cluster_port"
-api_addr      = "$api_addr"
+}\n
 EOF
 )
   fi
+
+  local -r ha_settings=$(cat <<EOF
+# HA settings
+cluster_addr  = "https://$instance_ip_address:$cluster_port"
+api_addr      = "$api_addr"
+\n
+EOF
+)
 
   vault_version_at_least "$config_path" "$ui_config"
 
   echo -e "$auto_unseal_config" >> "$config_path"
   echo -e "$listener_config" >> "$config_path"
-  echo -e "$s3_config" >> "$config_path"
   echo -e "$vault_storage_backend" >> "$config_path"
+  echo -e "$vault_ha_storage_backend" >> "$config_path"
+  echo -e "$ha_settings" >> "$config_path"
 
   chown "$user:$user" "$config_path"
 }
@@ -443,13 +468,15 @@ function run {
   local systemd_stderr=""
   local user=""
   local skip_vault_config="false"
-  local enable_s3_backend="false"
+  local storage_backend="consul"
+  local ha_storage_backend="consul"
   local s3_bucket=""
   local s3_bucket_path=""
   local s3_bucket_region=""
-  local enable_dynamo_backend="false"
   local dynamo_region=""
   local dynamo_table=""
+  local dynamo_ha_region=""
+  local dynamo_ha_table=""
   local agent="false"
   local agent_vault_address="$DEFAULT_AGENT_VAULT_ADDRESS"
   local agent_vault_port="$DEFAULT_PORT"
@@ -525,8 +552,15 @@ function run {
       --skip-vault-config)
         skip_vault_config="true"
         ;;
-      --enable-s3-backend)
-        enable_s3_backend="true"
+      --storage-backend)
+        assert_not_empty "$key" "$2"
+        storage_backend="$2"
+        shift
+        ;;
+      --ha-storage-backend)
+        assert_not_empty "$key" "$2"
+        ha_storage_backend="$2"
+        shift
         ;;
       --s3-bucket)
         s3_bucket="$2"
@@ -540,15 +574,20 @@ function run {
         s3_bucket_region="$2"
         shift
         ;;
-      --enable-dynamo-backend)
-        enable_dynamo_backend="true"
-        ;;
       --dynamo-region)
         dynamo_region="$2"
         shift
         ;;
       --dynamo-table)
         dynamo_table="$2"
+        shift
+        ;;
+      --dynamo-ha-region)
+        dynamo_ha_region="$2"
+        shift
+        ;;
+      --dynamo-ha-table)
+        dynamo_ha_table="$2"
         shift
         ;;
       --agent)
@@ -629,15 +668,20 @@ function run {
     assert_not_empty "--tls-cert-file" "$tls_cert_file"
     assert_not_empty "--tls-key-file" "$tls_key_file"
 
-    if [[ "$enable_s3_backend" == "true" ]]; then
+    if [[ "$storage_backend" == "s3" ]]; then
       assert_not_empty "--s3-bucket" "$s3_bucket"
       assert_not_empty "--s3-bucket-region" "$s3_bucket_region"
     fi
-  fi
-  
-  if [[ "$enable_dynamo_backend" == "true" ]]; then
-    assert_not_empty "--dynamo-table" "$dynamo_table"
-    assert_not_empty "--dynamo-region" "$dynamo_region"
+
+    if [[ "$storage_backend" == "dynamodb" ]]; then
+      assert_not_empty "--dynamo-table" "$dynamo_table"
+      assert_not_empty "--dynamo-region" "$dynamo_region"
+    fi
+
+    if [[ "$ha_storage_backend" == "dynamodb" ]]; then
+      assert_not_empty "--dynamo-ha-table" "$dynamo_ha_table"
+      assert_not_empty "--dynamo-ha-region" "$dynamo_ha_region"
+    fi
   fi
 
   assert_is_installed "systemctl"
@@ -703,13 +747,15 @@ function run {
         "$api_addr" \
         "$config_dir" \
         "$user" \
-        "$enable_s3_backend" \
+        "$storage_backend" \
+        "$ha_storage_backend" \
         "$s3_bucket" \
         "$s3_bucket_path" \
         "$s3_bucket_region" \
-        "$enable_dynamo_backend" \
         "$dynamo_region" \
         "$dynamo_table" \
+        "$dynamo_ha_region" \
+        "$dynamo_ha_table" \
         "$enable_auto_unseal" \
         "$auto_unseal_kms_key_id" \
         "$auto_unseal_kms_key_region" \

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -343,9 +343,9 @@ data "aws_iam_policy_document" "vault_dynamo" {
 }
 
 resource "aws_iam_role_policy" "vault_dynamo" {
-  count  = var.enable_dynamo_backend ? 1 : 0
-  name   = "vault_dynamo"
-  role   = aws_iam_role.instance_role.id
+  count = var.enable_dynamo_backend ? 1 : 0
+  name  = "vault_dynamo"
+  role  = aws_iam_role.instance_role.id
   policy = element(
     concat(data.aws_iam_policy_document.vault_dynamo.*.json, [""]),
     0,

--- a/test/vault_main_test.go
+++ b/test/vault_main_test.go
@@ -25,60 +25,65 @@ type amiData struct {
 }
 
 var amisData = []amiData{
-	{"vaultEnterpriseOnUbuntu18", "ubuntu18-ami", "ubuntu", true},
-	{"vaultEnterpriseOnUbuntu16", "ubuntu16-ami", "ubuntu", true},
-	{"vaultEnterpriseOnAmazonLinux", "amazon-linux-2-ami", "ec2-user", true},
+	// {"vaultEnterpriseOnUbuntu18", "ubuntu18-ami", "ubuntu", true},
+	// {"vaultEnterpriseOnUbuntu16", "ubuntu16-ami", "ubuntu", true},
+	// {"vaultEnterpriseOnAmazonLinux", "amazon-linux-2-ami", "ec2-user", true},
 	{"vaultOpenSourceOnUbuntu18", "ubuntu18-ami", "ubuntu", false},
-	{"vaultOpenSourceOnUbuntu16", "ubuntu16-ami", "ubuntu", false},
+	// {"vaultOpenSourceOnUbuntu16", "ubuntu16-ami", "ubuntu", false},
 	{"vaultOpenSourceOnAmazonLinux", "amazon-linux-2-ami", "ec2-user", false},
 }
 
 var testCases = []testCase{
-	{
-		"TestVaultAutoUnseal",
-		runVaultAutoUnsealTest,
-		false,
-	},
-	{
-		"TestEnterpriseInstallation",
-		runVaultEnterpriseClusterTest,
-		true,
-	},
-	{
-		"TestVaultEC2Auth",
-		runVaultEC2AuthTest,
-		false,
-	},
-	{
-		"TestVaultIAMAuth",
-		runVaultIAMAuthTest,
-		false,
-	},
+	// {
+	// 	"TestVaultAutoUnseal",
+	// 	runVaultAutoUnsealTest,
+	// 	false,
+	// },
+	// {
+	// 	"TestEnterpriseInstallation",
+	// 	runVaultEnterpriseClusterTest,
+	// 	true,
+	// },
+	// {
+	// 	"TestVaultEC2Auth",
+	// 	runVaultEC2AuthTest,
+	// 	false,
+	// },
+	// {
+	// 	"TestVaultIAMAuth",
+	// 	runVaultIAMAuthTest,
+	// 	false,
+	// },
 	{
 		"TestVaultWithS3Backend",
 		runVaultWithS3BackendClusterTest,
 		false,
 	},
-	{
-		"TestVaultWithDynamoDBBackend",
-		runVaultWithDynamoBackendClusterTest,
-		false,
-	},
-	{
-		"TestVaultPrivateCluster",
-		runVaultPrivateClusterTest,
-		false,
-	},
-	{
-		"TestVaultPublicCluster",
-		runVaultPublicClusterTest,
-		false,
-	},
-	{
-		"TestVaultAgent",
-		runVaultAgentTest,
-		false,
-	},
+	// {
+	// 	"TestVaultWithDynamoDBBackend",
+	// 	runVaultWithDynamoBackendClusterTest,
+	// 	false,
+	// },
+	// {
+	// 	"TestVaultWithDynamoDBStorageConsulBackend",
+	// 	runVaultWithDynamoStorageConsulHABackendClusterTest,
+	// 	false,
+	// },
+	// {
+	// 	"TestVaultPrivateCluster",
+	// 	runVaultPrivateClusterTest,
+	// 	false,
+	// },
+	// {
+	// 	"TestVaultPublicCluster",
+	// 	runVaultPublicClusterTest,
+	// 	false,
+	// },
+	// {
+	// 	"TestVaultAgent",
+	// 	runVaultAgentTest,
+	// 	false,
+	// },
 }
 
 func TestMainVaultCluster(t *testing.T) {
@@ -100,8 +105,8 @@ func TestMainVaultCluster(t *testing.T) {
 
 		amisPackerOptions := map[string]*packer.Options{}
 		for _, ami := range amisData {
-			// Exclude eu-north-1 as it is missing the instance types we use
-			awsRegion := aws.GetRandomRegion(t, nil, []string{"eu-north-1"})
+			// Exclude eu-north-1 & ap-south-1 as it is missing the instance types we use
+			awsRegion := aws.GetRandomRegion(t, nil, []string{"eu-north-1", "ap-south-1"})
 
 			test_structure.SaveString(t, WORK_DIR, fmt.Sprintf("awsRegion-%s", ami.Name), awsRegion)
 

--- a/test/vault_main_test.go
+++ b/test/vault_main_test.go
@@ -25,65 +25,60 @@ type amiData struct {
 }
 
 var amisData = []amiData{
-	// {"vaultEnterpriseOnUbuntu18", "ubuntu18-ami", "ubuntu", true},
-	// {"vaultEnterpriseOnUbuntu16", "ubuntu16-ami", "ubuntu", true},
-	// {"vaultEnterpriseOnAmazonLinux", "amazon-linux-2-ami", "ec2-user", true},
+	{"vaultEnterpriseOnUbuntu18", "ubuntu18-ami", "ubuntu", true},
+	{"vaultEnterpriseOnUbuntu16", "ubuntu16-ami", "ubuntu", true},
+	{"vaultEnterpriseOnAmazonLinux", "amazon-linux-2-ami", "ec2-user", true},
 	{"vaultOpenSourceOnUbuntu18", "ubuntu18-ami", "ubuntu", false},
-	// {"vaultOpenSourceOnUbuntu16", "ubuntu16-ami", "ubuntu", false},
+	{"vaultOpenSourceOnUbuntu16", "ubuntu16-ami", "ubuntu", false},
 	{"vaultOpenSourceOnAmazonLinux", "amazon-linux-2-ami", "ec2-user", false},
 }
 
 var testCases = []testCase{
-	// {
-	// 	"TestVaultAutoUnseal",
-	// 	runVaultAutoUnsealTest,
-	// 	false,
-	// },
-	// {
-	// 	"TestEnterpriseInstallation",
-	// 	runVaultEnterpriseClusterTest,
-	// 	true,
-	// },
-	// {
-	// 	"TestVaultEC2Auth",
-	// 	runVaultEC2AuthTest,
-	// 	false,
-	// },
-	// {
-	// 	"TestVaultIAMAuth",
-	// 	runVaultIAMAuthTest,
-	// 	false,
-	// },
+	{
+		"TestVaultAutoUnseal",
+		runVaultAutoUnsealTest,
+		false,
+	},
+	{
+		"TestEnterpriseInstallation",
+		runVaultEnterpriseClusterTest,
+		true,
+	},
+	{
+		"TestVaultEC2Auth",
+		runVaultEC2AuthTest,
+		false,
+	},
+	{
+		"TestVaultIAMAuth",
+		runVaultIAMAuthTest,
+		false,
+	},
 	{
 		"TestVaultWithS3Backend",
 		runVaultWithS3BackendClusterTest,
 		false,
 	},
-	// {
-	// 	"TestVaultWithDynamoDBBackend",
-	// 	runVaultWithDynamoBackendClusterTest,
-	// 	false,
-	// },
-	// {
-	// 	"TestVaultWithDynamoDBStorageConsulBackend",
-	// 	runVaultWithDynamoStorageConsulHABackendClusterTest,
-	// 	false,
-	// },
-	// {
-	// 	"TestVaultPrivateCluster",
-	// 	runVaultPrivateClusterTest,
-	// 	false,
-	// },
-	// {
-	// 	"TestVaultPublicCluster",
-	// 	runVaultPublicClusterTest,
-	// 	false,
-	// },
-	// {
-	// 	"TestVaultAgent",
-	// 	runVaultAgentTest,
-	// 	false,
-	// },
+	{
+		"TestVaultWithDynamoDBBackend",
+		runVaultWithDynamoBackendClusterTest,
+		false,
+	},
+	{
+		"TestVaultPrivateCluster",
+		runVaultPrivateClusterTest,
+		false,
+	},
+	{
+		"TestVaultPublicCluster",
+		runVaultPublicClusterTest,
+		false,
+	},
+	{
+		"TestVaultAgent",
+		runVaultAgentTest,
+		false,
+	},
 }
 
 func TestMainVaultCluster(t *testing.T) {


### PR DESCRIPTION

# Description
Change `run-vault` to support dynamo backend as either storage *or* HA storage. 

## Why
The implementation of DynamoDB has limited support only allowing DynamoDB as both the `storage` and `ha_storage` backend. 

It is valid to use DynamoDB as either. These combinations should all be valid but not currently possible

| Storage  | HA Storage |
|----------|------------|
| S3       | ~DynamoDB~ |
| S3       | Consul     |
| DynamoDB | DynamoDB   |
| DynamoDB | ~Consul~   |
| Consul   | ~DynamoDB~ |
| Consul   | Consul     |

This change enables you to specify the `--storage-backend` as any of `s3|dynamodb|consul` and the `--ha-storage-backend` as `dynamodb|consul`. 

Consul is the default for both to maintain expected behavior
