### PR TITLE
enable auto join for consul clients

### DIFF
--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -56,6 +56,11 @@ variable "auto_unseal_kms_key_arn" {
   default     = ""
 }
 
+variable "enable_consul_auto_join" {
+  description = "Enable auto join of the consul clients in the Vault cluster (if using Consul as the backend)"
+  default     = false
+}
+
 variable "subnet_ids" {
   description = "The subnet IDs into which the EC2 Instances should be deployed. You should typically pass in one subnet ID per node in the cluster_size variable. We strongly recommend that you run Vault in private subnets. At least one of var.subnet_ids or var.availability_zones must be non-empty."
   type        = list(string)


### PR DESCRIPTION
Consul seems to be the standard backend for this vault module, but cloud auto join is not supported currently because the IAM policies attached to the vault ec2 roles do not include the required permissions.  I've just copied these from the terraform-aws-consul module, though Consul itself claims it only needs the ec2:DescribeInstances permission set.

Tested as follows: Currently using this PR branch in place of the current master module in my own project, and cloud auto_join is working as expected.