### PR TITLE
Fix Vault Public Example to absolute ref

### DIFF
--- a/examples/vault-cluster-private/README.md
+++ b/examples/vault-cluster-private/README.md
@@ -7,7 +7,7 @@ using the [consul-cluster module](https://github.com/hashicorp/terraform-aws-con
 from the Consul AWS Module.
 
 This example creates a private Vault cluster, which is private in the sense that the EC2 Instances are not fronted by a
-load balancer, as is the case in the [Vault Public Example](/examples/root-example). Keep in mind that if the Vault
+load balancer, as is the case in the [Vault Public Example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/root-example). Keep in mind that if the Vault
 nodes are deployed to public subnets (i.e. subnets that have a route to the public Internet), this "private" cluster will
 still be accessible from the public Internet.
 


### PR DESCRIPTION
Fix link when used here https://registry.terraform.io/modules/hashicorp/vault/aws/0.13.1/examples/vault-cluster-private

Relative link breaks when displayed in registry. 