### PR TITLE
Edit default value for availability_zones and subnet_ids vars to null

### DIFF
--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -59,13 +59,13 @@ variable "auto_unseal_kms_key_arn" {
 variable "subnet_ids" {
   description = "The subnet IDs into which the EC2 Instances should be deployed. You should typically pass in one subnet ID per node in the cluster_size variable. We strongly recommend that you run Vault in private subnets. At least one of var.subnet_ids or var.availability_zones must be non-empty."
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "availability_zones" {
   description = "The availability zones into which the EC2 Instances should be deployed. You should typically pass in one availability zone per node in the cluster_size variable. We strongly recommend against passing in only a list of availability zones, as that will run Vault in the default (and most likely public) subnets in your VPC. At least one of var.subnet_ids or var.availability_zones must be non-empty."
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "ssh_key_name" {


### PR DESCRIPTION
Related to [Issue 181](https://github.com/hashicorp/terraform-aws-consul/issues/181) in `terraform-aws-consul`.

Newest `provider-aws` version only allows us to set one of the 2 variables: `availability_zones and subnet_ids` when creating AutoScalingGroups.

As per @brikis98 suggestion, I am changing the default value of these 2 variables to null so they're no longer conflicting, allowing to set either of them when using the `vault_cluster` module. 