### PR TITLE
Adding max_instance_lifetime to vault-cluster ASG

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -34,6 +34,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
 
   enabled_metrics = var.enabled_metrics
 
+  max_instance_lifetime = var.max_instance_lifetime
+  
   # Use bucket and policies names in tags for depending on them when they are there
   # And only create the cluster after S3 bucket and policies exist
   # Otherwise Vault might boot and not find the bucket or not yet have the necessary permissions

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -157,6 +157,11 @@ variable "wait_for_capacity_timeout" {
   default     = "10m"
 }
 
+variable "max_instance_lifetime" {
+  description = "The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 604800 and 31536000 seconds."
+  default = 0
+}
+
 variable "health_check_type" {
   description = "Controls how health checking is done. Must be one of EC2 or ELB."
   default     = "EC2"


### PR DESCRIPTION
Handy feature for those of us who need it, it's set to `0` by default which is effectively the same as before the change, but give people options.