### PR TITLE
Removing availability_zones from autoscaling_group in vault-cluster

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -19,7 +19,6 @@ resource "aws_autoscaling_group" "autoscaling_group" {
 
   launch_configuration = aws_launch_configuration.launch_configuration.name
 
-  availability_zones  = var.availability_zones
   vpc_zone_identifier = var.subnet_ids
 
   # Use a fixed-size cluster


### PR DESCRIPTION
Ran into an issue where a recent change in the aws_autoscaling_group resource caused the vault-cluster submodule to throw an error. Details in #220.