### PR TITLE
Update repo to work with TF 0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,6 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - validate_terraform:
-          filters:
-            branches:
-              ignore: publish-amis
       - test:
           filters:
             branches:
@@ -75,5 +71,4 @@ workflows:
               only:
                 - master
     jobs:
-      - validate_terraform
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,10 @@
 ---
-workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-vault
-
 defaults: &defaults
-  working_directory: *workspace_root
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.13
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:tf13.4
 
 version: 2
 jobs:
-  validate_terraform:
-    docker:
-      - image: hashicorp/terraform
-    steps:
-      - checkout
-      - run:
-          name: Validate Terraform Formatting
-          command: '[ -z "$(terraform fmt -write=false)" ] || { terraform fmt -write=false -diff; exit 1; }'
-
   test:
     <<: *defaults
     steps:
@@ -24,8 +12,14 @@ jobs:
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
       # Domain name of Route 53 hosted zone to use at test time
       - run: echo 'export VAULT_HOSTED_ZONE_DOMAIN_NAME=gruntwork.in' >> $BASH_ENV
-      - attach_workspace:
-          at: *workspace_root
+      - run:
+          # Fail the build if the pre-commit hooks don't pass. Note: if you run $ pre-commit install locally within this repo, these hooks will
+          # execute automatically every time before you commit, ensuring the build never fails at this step!
+          name: run pre-commit hooks
+          command: |
+            pip install pre-commit==1.21.0 cfgv==2.0.1
+            pre-commit install
+            pre-commit run --all-files
       - run:
           command: |
             mkdir -p /tmp/logs
@@ -50,9 +44,9 @@ jobs:
       # We generally only want to build AMIs on new releases, but when we are setting up AMIs in a new account for the
       # first time, we want to build the AMIs but NOT run automated tests, since those tests will fail without an existing
       # AMI already in the AWS Account.
-      - run: /go/src/github.com/hashicorp/terraform-aws-vault/_ci/publish-amis.sh "ubuntu16-ami"
-      - run: /go/src/github.com/hashicorp/terraform-aws-vault/_ci/publish-amis.sh "ubuntu18-ami"
-      - run: /go/src/github.com/hashicorp/terraform-aws-vault/_ci/publish-amis.sh "amazon-linux-2-ami"
+      - run: _ci/publish-amis.sh "ubuntu16-ami"
+      - run: _ci/publish-amis.sh "ubuntu18-ami"
+      - run: _ci/publish-amis.sh "amazon-linux-2-ami"
 
 workflows:
   version: 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev:  v0.1.10
+    hooks:
+      - id: terraform-fmt
+      - id: gofmt

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ To deploy the Vault cluster:
    module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul)). Here is an
    [example Packer template](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami).
 
-   If you are just experimenting with this Module, you may find it more convenient to use one of our official public AMIs:
-   - [Latest Ubuntu 16 AMIs](https://github.com/hashicorp/terraform-aws-vault/tree/master/_docs/ubuntu16-ami-list.md).
-   - [Latest Amazon Linux 2 AMIs](https://github.com/hashicorp/terraform-aws-vault/tree/master/_docs/amazon-linux-ami-list.md).
+   If you are just experimenting with this Module, you may find it more convenient to use one of our official public AMIs.
+   Check out the `aws_ami` data source usage in `main.tf` for how to auto-discover this AMI.
 
    **WARNING! Do NOT use these AMIs in your production setup. In production, you should build your own AMIs in your
      own AWS account.**

--- a/_ci/publish-amis.sh
+++ b/_ci/publish-amis.sh
@@ -11,10 +11,6 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly PACKER_TEMPLATE_PATH="$SCRIPT_DIR/../examples/vault-consul-ami/vault-consul.json"
 readonly PACKER_TEMPLATE_DEFAULT_REGION="us-east-1"
 readonly AMI_PROPERTIES_FILE="/tmp/ami.properties"
-readonly AMI_LIST_MARKDOWN_DIR="$SCRIPT_DIR/../_docs"
-readonly GIT_COMMIT_MESSAGE="Add latest AMI IDs."
-readonly GIT_USER_NAME="gruntwork-ci"
-readonly GIT_USER_EMAIL="ci@gruntwork.io"
 
 # In CircleCI, every build populates the branch name in CIRCLE_BRANCH...except builds triggered by a new tag, for which
 # the CIRCLE_BRANCH env var is empty. We assume tags are only issued against the master branch.
@@ -55,15 +51,5 @@ publish-ami \
   --all-regions \
   --source-ami-id "$ARTIFACT_ID" \
   --source-ami-region "$PACKER_TEMPLATE_DEFAULT_REGION" \
-  --output-markdown > "$AMI_LIST_MARKDOWN_DIR/$PACKER_BUILD_NAME-list.md" \
   --markdown-title-text "$PACKER_BUILD_NAME: Latest Public AMIs" \
   --markdown-description-text "**WARNING! Do NOT use these AMIs in a production setting.** They contain TLS certificate files that are publicly available through this repo and using these AMIs in production would represent a serious security risk. The AMIs are meant only to make initial experiments with this module more convenient."
-
-# Git add, commit, and push the newly created AMI IDs as a markdown doc to the repo
-git-add-commit-push \
-  --path "$AMI_LIST_MARKDOWN_DIR/$PACKER_BUILD_NAME-list.md" \
-  --message "$GIT_COMMIT_MESSAGE" \
-  --user-name "$GIT_USER_NAME" \
-  --user-email "$GIT_USER_EMAIL" \
-  --git-push-behavior "current" \
-  --branch-name "$BRANCH_NAME"

--- a/examples/vault-agent/main.tf
+++ b/examples/vault-agent/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/vault-agent/main.tf
+++ b/examples/vault-agent/main.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "example_instance_role" {
 
 # Adds policies necessary for running consul
 module "consul_iam_policies_for_client" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = aws_iam_role.example_instance_role.id
 }
@@ -170,7 +170,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
 }
@@ -201,7 +201,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.8.0"
 
   security_group_id = module.vault_cluster.security_group_id
 
@@ -216,7 +216,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.8.0"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size

--- a/examples/vault-auto-unseal/main.tf
+++ b/examples/vault-auto-unseal/main.tf
@@ -55,7 +55,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
 }
@@ -83,7 +83,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.8.0"
 
   security_group_id = module.vault_cluster.security_group_id
 
@@ -98,7 +98,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.8.0"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size

--- a/examples/vault-auto-unseal/main.tf
+++ b/examples/vault-auto-unseal/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 data "aws_kms_alias" "vault-example" {

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -45,7 +45,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
 }
@@ -72,7 +72,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.8.0"
 
   security_group_id = module.vault_cluster.security_group_id
 
@@ -87,7 +87,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.8.0"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size

--- a/examples/vault-consul-ami/vault-consul.json
+++ b/examples/vault-consul-ami/vault-consul.json
@@ -3,7 +3,7 @@
   "variables": {
     "aws_region": "us-east-1",
     "vault_version": "1.5.4",
-    "consul_module_version": "v0.7.3",
+    "consul_module_version": "v0.8.0",
     "consul_version": "1.5.3",
     "consul_download_url": "{{env `CONSUL_DOWNLOAD_URL`}}",
     "vault_download_url": "{{env `VAULT_DOWNLOAD_URL`}}",

--- a/examples/vault-dynamodb-backend/dynamodb/main.tf
+++ b/examples/vault-dynamodb-backend/dynamodb/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
 resource "aws_dynamodb_table" "vault_dynamo" {
   name           = var.table_name
   hash_key       = "Path"

--- a/examples/vault-dynamodb-backend/main.tf
+++ b/examples/vault-dynamodb-backend/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/vault-dynamodb-backend/main.tf
+++ b/examples/vault-dynamodb-backend/main.tf
@@ -45,7 +45,7 @@ module "vault_cluster" {
   ssh_key_name                         = var.ssh_key_name
 
   enable_dynamo_backend = true
-  dynamo_table_name = var.dynamo_table_name
+  dynamo_table_name     = var.dynamo_table_name
 }
 
 data "template_file" "user_data_vault_cluster" {

--- a/examples/vault-ec2-auth/main.tf
+++ b/examples/vault-ec2-auth/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 resource "aws_instance" "example_auth_to_vault" {

--- a/examples/vault-ec2-auth/main.tf
+++ b/examples/vault-ec2-auth/main.tf
@@ -109,7 +109,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
 }
@@ -141,7 +141,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.8.0"
 
   security_group_id = module.vault_cluster.security_group_id
 
@@ -156,7 +156,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.8.0"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size

--- a/examples/vault-iam-auth/main.tf
+++ b/examples/vault-iam-auth/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/vault-iam-auth/main.tf
+++ b/examples/vault-iam-auth/main.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "example_instance_role" {
 
 # Adds policies necessary for running consul
 module "consul_iam_policies_for_client" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = aws_iam_role.example_instance_role.id
 }
@@ -170,7 +170,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
 }
@@ -201,7 +201,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.8.0"
 
   security_group_id = module.vault_cluster.security_group_id
 
@@ -216,7 +216,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.8.0"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/vault-s3-backend/main.tf
+++ b/examples/vault-s3-backend/main.tf
@@ -49,7 +49,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
 }
@@ -77,7 +77,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.8.0"
 
   security_group_id = module.vault_cluster.security_group_id
 
@@ -92,7 +92,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.8.0"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size

--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,7 @@ module "vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
 }
@@ -119,7 +119,7 @@ data "template_file" "user_data_vault_cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "security_group_rules" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.8.0"
 
   security_group_id = module.vault_cluster.security_group_id
 
@@ -172,7 +172,7 @@ data "aws_route53_zone" "selected" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.7.7"
+  source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.8.0"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,12 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/private-tls-cert/main.tf
+++ b/modules/private-tls-cert/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 #  CREATE A CA CERTIFICATE
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 data "aws_region" "current" {}

--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vault-security-group-rules/main.tf
+++ b/modules/vault-security-group-rules/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # CREATE THE SECURITY GROUP RULES THAT CONTROL WHAT TRAFFIC CAN GO IN AND OUT OF A VAULT CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------

--- a/test/aws_helpers.go
+++ b/test/aws_helpers.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"testing"
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"testing"
 )
 
 // Get the public IP addresses of the EC2 Instances in an Auto Scaling Group of the given name in the given

--- a/test/tls_helpers.go
+++ b/test/tls_helpers.go
@@ -1,12 +1,12 @@
 package test
 
 import (
-	"testing"
-	"os/user"
-	"io/ioutil"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
+	"io/ioutil"
+	"os/user"
 	"strings"
+	"testing"
 )
 
 type TlsCert struct {

--- a/test/vault_cluster_auth_test.go
+++ b/test/vault_cluster_auth_test.go
@@ -159,7 +159,7 @@ func testRequestSecret(t *testing.T, terraformOptions *terraform.Options, expect
 	instanceIP := terraform.Output(t, terraformOptions, OUTPUT_AUTH_CLIENT_IP)
 	url := fmt.Sprintf("http://%s:%s", instanceIP, "8080")
 
-	http_helper.HttpGetWithRetry(t, url, nil, 200, expectedResponse, 30, 10*time.Second)
+	http_helper.HttpGetWithRetry(t, url, nil, 200, expectedResponse, 60, 10*time.Second)
 }
 
 func getSyslogs(t *testing.T, terraformOptions *terraform.Options, amiId string, awsRegion string, testName string) {

--- a/test/vault_main_test.go
+++ b/test/vault_main_test.go
@@ -101,7 +101,7 @@ func TestMainVaultCluster(t *testing.T) {
 		amisPackerOptions := map[string]*packer.Options{}
 		for _, ami := range amisData {
 			// Exclude a few regions as they are missing the instance types we use
-			awsRegion := aws.GetRandomRegion(t, nil, []string{"eu-north-1", "ca-central-1"})
+			awsRegion := aws.GetRandomRegion(t, nil, []string{"eu-north-1", "ca-central-1", "ap-northeast-2"})
 
 			test_structure.SaveString(t, WORK_DIR, fmt.Sprintf("awsRegion-%s", ami.Name), awsRegion)
 


### PR DESCRIPTION
1. Update `required_version` to `0.12.26` everywhere.
1. Add pre-commit hooks.
1. Update version numbers in CI build.
1. Run `go fmt` and `terraform fmt`.
1. Remove updating of Markdown files when we publish AMIs. Too much work to maintain, not enough value.