### PR TITLE
Fixed link to "Latest Amazon Linux 2 AMIs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To deploy the Vault cluster:
 
    If you are just experimenting with this Module, you may find it more convenient to use one of our official public AMIs:
    - [Latest Ubuntu 16 AMIs](https://github.com/hashicorp/terraform-aws-vault/tree/master/_docs/ubuntu16-ami-list.md).
-   - [Latest Amazon Linux 2 AMIs](https://github.com/hashicorp/terraform-aws-vault/tree/master/_docs/amazon-linux-ami-list.md).
+   - [Latest Amazon Linux 2 AMIs](https://github.com/hashicorp/terraform-aws-vault/tree/master/_docs/amazon-linux-2-ami-list.md).
 
    **WARNING! Do NOT use these AMIs in your production setup. In production, you should build your own AMIs in your
      own AWS account.**


### PR DESCRIPTION

Fixed link to "Latest Amazon Linux 2 AMIs" 

The link took me to the wrong page, I used the outdated AMI and then I spent about an hour wondering how come DynamoDB is not supported etc.