### PR TITLE
Add `permissions_boundary` for created IAM role.

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -246,6 +246,8 @@ resource "aws_iam_role" "instance_role" {
   name_prefix        = var.cluster_name
   assume_role_policy = data.aws_iam_policy_document.instance_role.json
 
+  permissions_boundary = var.iam_permissions_boundary
+
   # aws_iam_instance_profile.instance_profile in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
   # when you try to do a terraform destroy.

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -236,3 +236,9 @@ variable "dynamo_table_region" {
   type        = string
   default     = ""
 }
+
+variable "iam_permissions_boundary" {
+  description = "If set, restricts the created IAM role to the given permissions boundary"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Provides flexibility to users for setting `permissions_boundary` to the created IAM role.

Defaults to `null` to preserve the same behavior as before.