### PR TITLE
Add option to use_existing_s3_bucket instead of creating one.

### DIFF
--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -47,6 +47,6 @@ output "security_group_id" {
 }
 
 output "s3_bucket_arn" {
-  value = join(",", aws_s3_bucket.vault_storage.*.arn)
+  value = local.s3_bucket_arn
 }
 

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -192,24 +192,29 @@ variable "enable_s3_backend" {
   default     = false
 }
 
+variable "use_existing_s3_bucket" {
+  description = "If true, use an existing S3 bucket (provided by s3_bucket_name) instead of creating the bucket within this module."
+  default     = false
+}
+
 variable "s3_bucket_name" {
   description = "The name of the S3 bucket to create and use as a storage backend. Only used if 'enable_s3_backend' is set to true."
   default     = ""
 }
 
 variable "s3_bucket_tags" {
-  description = "Tags to be applied to the S3 bucket."
+  description = "Tags to be applied to the S3 bucket. Applied only when 'use_existing_s3_bucket' is false."
   type        = map(string)
   default     = {}
 }
 
 variable "enable_s3_bucket_versioning" {
-  description = "Whether to enable bucket versioning for the S3 bucket."
+  description = "Whether to enable bucket versioning for the S3 bucket.  Applied only when 'use_existing_s3_bucket' is false."
   default     = false
 }
 
 variable "force_destroy_s3_bucket" {
-  description = "If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true."
+  description = "If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true and 'use_existing_s3_bucket' is false."
   default     = false
 }
 


### PR DESCRIPTION
If var.use_existing_s3_bucket is true, will acquire the bucket id and arn by the provided var.s3_bucket_name instead of creating a new bucket in this module.  This allows a user to avoid creating and destroying the S3 bucket repeatedly, and they can persist configuration from the s3 backend even after destroying this module.