### PR TITLE
feat(install-vault): add multiarch support

### DIFF
--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -176,8 +176,30 @@ function fetch_binary {
   local -r version="$1"
   local download_url="$2"
 
+  local cpu_arch
+  cpu_arch="$(uname -m)"
+  local binary_arch=""
+  case "$cpu_arch" in
+    x86_64)
+      binary_arch="amd64"
+      ;;
+    x86)
+      binary_arch="386"
+      ;;
+    arm64|aarch64)
+      binary_arch="arm64"
+      ;;
+    arm*)
+      binary_arch="arm"
+      ;;
+    *)
+      log_error "CPU architecture $cpu_arch is not a supported by Vault."
+      exit 1
+      ;;
+    esac
+
   if [[ -z "$download_url" && -n "$version" ]];  then
-    download_url="https://releases.hashicorp.com/vault/${version}/vault_${version}_linux_amd64.zip"
+    download_url="https://releases.hashicorp.com/vault/${version}/vault_${version}_linux_${binary_arch}.zip"
   fi
 
   retry \


### PR DESCRIPTION
## Description

Adds ability to fetch vault binary according to the host arch to the install-vault script.

Employs the approach used by the [install-nomad script](https://github.com/hashicorp/terraform-aws-nomad/blob/master/modules/install-nomad/install-nomad#L130-L152) in the terraform-aws-nomad repo.

### Documentation

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.

## Related Issues

Fixes https://github.com/hashicorp/terraform-aws-vault/issues/249
