### PR TITLE
Replace deprecated "template_file" resource for "templatefile" function.

### DIFF
--- a/examples/vault-agent/main.tf
+++ b/examples/vault-agent/main.tf
@@ -24,7 +24,15 @@ resource "aws_instance" "example_auth_to_vault" {
     aws_security_group.auth_instance.id,
   ]
 
-  user_data            = data.template_file.user_data_auth_client.rendered
+  # The user data script that will run on the instance
+  # This script will run consul, which is used for discovering vault cluster
+  # And perform the login operation
+  user_data            = templatefile("${path.module}/user-data-auth-client.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+    example_role_name        = var.example_role_name
+  })
+
   iam_instance_profile = aws_iam_instance_profile.example_instance_profile.name
 
   tags = {
@@ -64,22 +72,6 @@ module "consul_iam_policies_for_client" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = aws_iam_role.example_instance_role.id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON THE INSTANCE
-# This script will run consul, which is used for discovering vault cluster
-# And perform the login operation
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_auth_client" {
-  template = file("${path.module}/user-data-auth-client.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-    example_role_name        = var.example_role_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -148,7 +140,18 @@ module "vault_cluster" {
   instance_type = var.vault_instance_type
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_vault_cluster.rendered
+
+  # The user data script that will run on each Vault server when it's booting
+  # This script will configure and start Vault
+  user_data = templatefile("${path.module}/user-data-vault.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+    example_role_name        = var.example_role_name
+    # Please note that normally we would never pass a secret this way
+    # This is just for test purposes so we can verify that our example instance is authenticating correctly
+    example_secret           = var.example_secret
+    aws_iam_role_arn         = aws_iam_role.example_instance_role.arn
+  })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -173,25 +176,6 @@ module "consul_iam_policies_servers" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH VAULT SERVER WHEN IT'S BOOTING
-# This script will configure and start Vault
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_vault_cluster" {
-  template = file("${path.module}/user-data-vault.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-    example_role_name        = var.example_role_name
-    # Please note that normally we would never pass a secret this way
-    # This is just for test purposes so we can verify that our example instance is authenticating correctly
-    example_secret   = var.example_secret
-    aws_iam_role_arn = aws_iam_role.example_instance_role.arn
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -227,7 +211,12 @@ module "consul_cluster" {
   cluster_tag_value = var.consul_cluster_name
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_consul.rendered
+  # The user data script that will run o eacht consul server when it's booting
+  # This script will configure and start Consul
+  user_data = templatefile("${path.module}/user-data-consul.sh", {
+    consul_cluster_tag_key= var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+  })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -238,20 +227,6 @@ module "consul_cluster" {
   allowed_ssh_cidr_blocks     = ["0.0.0.0/0"]
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = var.ssh_key_name
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH CONSUL SERVER WHEN IT'S BOOTING
-# This script will configure and start Consul
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_consul" {
-  template = file("${path.module}/user-data-consul.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -272,4 +247,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-

--- a/examples/vault-auto-unseal/main.tf
+++ b/examples/vault-auto-unseal/main.tf
@@ -27,7 +27,15 @@ module "vault_cluster" {
   instance_type = var.vault_instance_type
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_vault_cluster.rendered
+
+  # The user data script that will run on each vault server when it's booting
+  # This script will configure and start Vault
+  user_data = templatefile("${path.module}/user-data-vault.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+    kms_key_id               = data.aws_kms_alias.vault-example.target_key_id
+    aws_region               = data.aws_region.current.name
+  })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -58,22 +66,6 @@ module "consul_iam_policies_servers" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH VAULT SERVER WHEN IT'S BOOTING
-# This script will configure and start Vault
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_vault_cluster" {
-  template = file("${path.module}/user-data-vault.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-    kms_key_id               = data.aws_kms_alias.vault-example.target_key_id
-    aws_region               = data.aws_region.current.name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -109,7 +101,13 @@ module "consul_cluster" {
   cluster_tag_value = var.consul_cluster_name
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_consul.rendered
+
+  # The user data script that will run on eacht consul server when it's booting
+  # This script will configure and start Consul
+  user_data = templatefile("${path.module}/user-data-consul.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+  })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -120,20 +118,6 @@ module "consul_cluster" {
   allowed_ssh_cidr_blocks     = ["0.0.0.0/0"]
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = var.ssh_key_name
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH CONSUL SERVER WHEN IT'S BOOTING
-# This script will configure and start Consul
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_consul" {
-  template = file("${path.module}/user-data-consul.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -154,4 +138,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -23,7 +23,14 @@ module "vault_cluster" {
   instance_type = var.vault_instance_type
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_vault_cluster.rendered
+
+  # The user data script that will run on each vault server when it's booting
+  # This script will configure and start Vault
+  user_data = templatefile("${path.module}/user-data-vault.sh", {
+    aws_region               = data.aws_region.current.name
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+  })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -48,21 +55,6 @@ module "consul_iam_policies_servers" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH VAULT SERVER WHEN IT'S BOOTING
-# This script will configure and start Vault
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_vault_cluster" {
-  template = file("${path.module}/user-data-vault.sh")
-
-  vars = {
-    aws_region               = data.aws_region.current.name
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -98,8 +90,14 @@ module "consul_cluster" {
   cluster_tag_value = var.consul_cluster_name
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_consul.rendered
 
+  # The user data script that will run on each consul server when it's booting
+  # This script will configure and start Consul
+  user_data = templatefile("${path.module}/user-data-consul.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+  })
+  
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
 
@@ -109,20 +107,6 @@ module "consul_cluster" {
   allowed_ssh_cidr_blocks     = ["0.0.0.0/0"]
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = var.ssh_key_name
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH CONSUL SERVER WHEN IT'S BOOTING
-# This script will configure and start Consul
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_consul" {
-  template = file("${path.module}/user-data-consul.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -143,4 +127,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-

--- a/examples/vault-iam-auth/main.tf
+++ b/examples/vault-iam-auth/main.tf
@@ -24,7 +24,15 @@ resource "aws_instance" "example_auth_to_vault" {
     aws_security_group.auth_instance.id,
   ]
 
-  user_data            = data.template_file.user_data_auth_client.rendered
+  # The user data script that will run on the instance
+  # This script will run consul, which is used for discovering vault cluster
+  # And perform the login operation
+  user_data            = templatefile("${path.module}/user-data-auth-client.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+    example_role_name        = var.example_role_name
+  })
+
   iam_instance_profile = aws_iam_instance_profile.example_instance_profile.name
 
   tags = {
@@ -64,22 +72,6 @@ module "consul_iam_policies_for_client" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = aws_iam_role.example_instance_role.id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON THE INSTANCE
-# This script will run consul, which is used for discovering vault cluster
-# And perform the login operation
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_auth_client" {
-  template = file("${path.module}/user-data-auth-client.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-    example_role_name        = var.example_role_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -148,7 +140,18 @@ module "vault_cluster" {
   instance_type = var.vault_instance_type
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_vault_cluster.rendered
+
+  # The user data script that will run on each Vault server when it's booting
+  # This script will configure and start Vault
+  user_data = templatefile("${path.module}/user-data-vault.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+    example_role_name        = var.example_role_name
+    # Please note that normally we would never pass a secret this way
+    # This is just for test purposes so we can verify that our example instance is authenticating correctly
+    example_secret   = var.example_secret
+    aws_iam_role_arn = aws_iam_role.example_instance_role.arn
+  })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -173,25 +176,6 @@ module "consul_iam_policies_servers" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH VAULT SERVER WHEN IT'S BOOTING
-# This script will configure and start Vault
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_vault_cluster" {
-  template = file("${path.module}/user-data-vault.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-    example_role_name        = var.example_role_name
-    # Please note that normally we would never pass a secret this way
-    # This is just for test purposes so we can verify that our example instance is authenticating correctly
-    example_secret   = var.example_secret
-    aws_iam_role_arn = aws_iam_role.example_instance_role.arn
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -227,7 +211,13 @@ module "consul_cluster" {
   cluster_tag_value = var.consul_cluster_name
 
   ami_id    = var.ami_id
-  user_data = data.template_file.user_data_consul.rendered
+
+  # The user data script that will run on each consul server when it's booting
+  # This script will configure and start Consul
+  user_data = templatefile("${path.module}/user-data-consul.sh", {
+    consul_cluster_tag_key   = var.consul_cluster_tag_key
+    consul_cluster_tag_value = var.consul_cluster_name
+  })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -238,20 +228,6 @@ module "consul_cluster" {
   allowed_ssh_cidr_blocks     = ["0.0.0.0/0"]
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = var.ssh_key_name
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH CONSUL SERVER WHEN IT'S BOOTING
-# This script will configure and start Consul
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_consul" {
-  template = file("${path.module}/user-data-consul.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -272,4 +248,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,9 @@ module "vault_cluster" {
   instance_type = var.vault_instance_type
 
   ami_id    = var.ami_id == null ? data.aws_ami.vault_consul.image_id : var.ami_id
-  user_data = data.template_file.user_data_vault_cluster.rendered
+  # The user data script that will run on eacht Vault server when it's booting
+  # This script will configure and start Vault
+  user_data = templatefile("${path.module}/examples/root-example/user-data-vault.sh", { aws_region = data.aws_region.current.name, consul_cluster_tag_key = var.consul_cluster_tag_key, consul_cluster_tag_value = var.consul_cluster_name })
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -95,21 +97,6 @@ module "consul_iam_policies_servers" {
   source = "github.com/hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.8.0"
 
   iam_role_id = module.vault_cluster.iam_role_id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH VAULT SERVER WHEN IT'S BOOTING
-# This script will configure and start Vault
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_vault_cluster" {
-  template = file("${path.module}/examples/root-example/user-data-vault.sh")
-
-  vars = {
-    aws_region               = data.aws_region.current.name
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -183,7 +170,9 @@ module "consul_cluster" {
   cluster_tag_value = var.consul_cluster_name
 
   ami_id    = var.ami_id == null ? data.aws_ami.vault_consul.image_id : var.ami_id
-  user_data = data.template_file.user_data_consul.rendered
+  # The user data script that will run on each consul server when it's booting
+  # This script will configure and start Consul
+  user_date = templatefile("${path.module}/examples/root-example/user-data-consul.sh", {consul_cluster_tag_key = var.consul_cluster_tag_key, consul_cluster_tag_value = var.consul_cluster_name})
 
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
@@ -194,20 +183,6 @@ module "consul_cluster" {
   allowed_ssh_cidr_blocks     = ["0.0.0.0/0"]
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = var.ssh_key_name
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# THE USER DATA SCRIPT THAT WILL RUN ON EACH CONSUL SERVER WHEN IT'S BOOTING
-# This script will configure and start Consul
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "template_file" "user_data_consul" {
-  template = file("${path.module}/examples/root-example/user-data-consul.sh")
-
-  vars = {
-    consul_cluster_tag_key   = var.consul_cluster_tag_key
-    consul_cluster_tag_value = var.consul_cluster_name
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -229,4 +204,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-


### PR DESCRIPTION
## Description

The [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) resource is deprecated. Instead the [templatefile](https://www.terraform.io/docs/language/functions/templatefile.html) function is used.

The deprecation makes it difficult for Mac OS X - M1 users to use this code as no binary is available.

### Documentation

The code is fully compatible with previous version, no documentation changes are required.