### PR TITLE
Add kms key creation for vault auto unseal

### DIFF
--- a/examples/vault-auto-unseal/README.md
+++ b/examples/vault-auto-unseal/README.md
@@ -32,22 +32,17 @@ even if you immediately delete it.
 ### Quick start
 
 1. `git clone` this repo to your computer.
-1. Build a Vault and Consul AMI. See the [vault-consul-ami example][vault_consul_ami]
+2. Build a Vault and Consul AMI. See the [vault-consul-ami example][vault_consul_ami]
   documentation for instructions. Don't forget to set the variable `vault_download_url`
   with the url of the enterprise version of Vault if you wish to use Vault Enterprise.
   Make sure to note down the ID of the AMI.
-1. Install [Terraform][terraform].
-1. [Create an AWS KMS key][key_creation]. Take note of the key alias.
-1. Open `variables.tf`, set the environment variables specified at the top of the file,
-  and fill in any other variables that don't have a default. Put the AMI ID you
-  previously took note into the `ami_id` variable and the KMS key alias into
-  `auto_unseal_kms_key_alias`.
-1. Run `terraform init`.
-1. Run `terraform apply`.
-1. Run the [vault-examples-helper.sh script][examples_helper] to
+3. Install [Terraform][terraform].
+4. Run `terraform init`.
+5. Run `terraform apply`.
+6. Run the [vault-examples-helper.sh script][examples_helper] to
    print out the IP addresses of the Vault server and some example commands you
    can run to interact with the cluster: `../vault-examples-helper/vault-examples-helper.sh`.
-1. Ssh to an instance in the vault cluster and run `vault operator init` to initialize
+7. Ssh to an instance in the vault cluster and run `vault operator init` to initialize
   the cluster, then `vault status` to check that it is unsealed. If you ssh to a
   different node in the cluster, you might have to restart Vault first with
   `sudo systemctl restart vault.service` so it will rejoin the cluster and unseal.
@@ -91,17 +86,10 @@ you to pass the following flags to it:
 
 In this example, like in other examples, we execute `run-vault` at the [`user-data`
 script][user_data], which runs on boot for every node in the Vault cluster. The
-`key-id` is passed to this script by Terraform, after Terraform reads this value from a
-data source through the key alias. This means that the AWS key has to be previously
-manually created and we are using Terraform just to find this resource, not to
-create it. It is important to notice that AWS KMS keys have a [cost][kms_pricing]
+`key-id` is passed to this script by Terraform, after Terraform reads this value from a 
+resource block that creates the KMS key as given in the file - `kms.tf`. 
+It is important to notice that AWS KMS keys have a [cost][kms_pricing]
 per month per key, as well as an API usage cost.
-
-```
-data "aws_kms_alias" "vault-example" {
-  name = "alias/${var.auto_unseal_kms_key_alias}"
-}
-```
 
 If you wish to use Vault Enterprise, you still need to apply your Vault
 Enterprise License to the cluster with `vault write /sys/license "text=$LICENSE_KEY_TEXT"`.

--- a/examples/vault-auto-unseal/kms.tf
+++ b/examples/vault-auto-unseal/kms.tf
@@ -1,0 +1,71 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GET CURRENT ACCOUNT INFORMATION
+# -------------------------------
+
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY THE VAULT KMS KEY
+# -------------------------
+
+resource "aws_kms_key" "vault_kms_mr_key" {
+  deletion_window_in_days  = 30
+  description              = "AWS Vault Master Key"
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  multi_region             = true
+  policy                   = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Id": "vault-key",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions for owner account",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "kms:GetPublicKey",
+                "kms:Decrypt",
+                "kms:ListKeyPolicies",
+                "kms:GenerateRandom",
+                "kms:ListRetirableGrants",
+                "kms:GetKeyPolicy",
+                "kms:Verify",
+                "kms:ListResourceTags",
+                "kms:GenerateDataKeyPair",
+                "kms:ReEncryptFrom",
+                "kms:ListGrants",
+                "kms:GetParametersForImport",
+                "kms:DescribeCustomKeyStores",
+                "kms:ListKeys",
+                "kms:Encrypt",
+                "kms:GetKeyRotationStatus",
+                "kms:ListAliases",
+                "kms:GenerateDataKey",
+                "kms:ReEncryptTo",
+                "kms:DescribeKey",
+                "kms:Sign",
+                "kms:CreateGrant"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_kms_alias" "vault_kms_mr_key_alias" {
+  name          = "alias/multi-region-vault-master-key"
+  target_key_id = aws_kms_key.vault_kms_mr_key.key_id
+}

--- a/examples/vault-auto-unseal/main.tf
+++ b/examples/vault-auto-unseal/main.tf
@@ -8,10 +8,6 @@ terraform {
   required_version = ">= 0.12.26"
 }
 
-data "aws_kms_alias" "vault-example" {
-  name = "alias/${var.auto_unseal_kms_key_alias}"
-}
-
 # ---------------------------------------------------------------------------------------------------------------------
 # DEPLOY THE VAULT SERVER CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
@@ -36,7 +32,7 @@ module "vault_cluster" {
   # access KMS and use this key for encryption and decryption
   enable_auto_unseal = true
 
-  auto_unseal_kms_key_arn = data.aws_kms_alias.vault-example.target_key_arn
+  auto_unseal_kms_key_arn = aws_kms_alias.vault_kms_mr_key.target_key_arn
 
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we *strongly*
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
@@ -71,7 +67,7 @@ data "template_file" "user_data_vault_cluster" {
   vars = {
     consul_cluster_tag_key   = var.consul_cluster_tag_key
     consul_cluster_tag_value = var.consul_cluster_name
-    kms_key_id               = data.aws_kms_alias.vault-example.target_key_id
+    kms_key_id               = aws_kms_alias.vault_kms_mr_key.target_key_id
     aws_region               = data.aws_region.current.name
   }
 }


### PR DESCRIPTION
## Description

As of today, the KMS key creation process is manual outside the scope of the example - vault-auto-unseal and we are trying to bring this into Terraform. This adds Terraform source code for creating a KMS key for auto-unseal to work. This also provides a KMS key replication to another region.

### Documentation
We have updated the documentation inside `examples/vault-auto-unseal/README.md`

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues
Addresses #257

