### PR TITLE
Fix versioning for S3 bucket

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -280,15 +280,19 @@ resource "aws_s3_bucket" "vault_storage" {
     var.s3_bucket_tags,
   )
 
-  versioning {
-    enabled = var.enable_s3_bucket_versioning
-  }
-
   # aws_launch_configuration.launch_configuration in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
   # when you try to do a terraform destroy.
   lifecycle {
     create_before_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "vault_storage" {
+  count  = var.enable_s3_backend ? 1 : 0
+  bucket = aws_s3_bucket.vault_storage[count.index].id
+  versioning_configuration {
+    status = var.enable_s3_bucket_versioning
   }
 }
 


### PR DESCRIPTION
New Provider expect separate resource for versioning instead of place the statement inside the resource for bucket createtion.

<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Newest version of TF Provider introduced some changes into the way we manage S3 bucket and its policies, versioning and acl. This PR aims to fix the discrepancy which has been presented once the new provider has been introduced.

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues
Fixes #262 
<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
